### PR TITLE
Update filename case in WrenchLogger check

### DIFF
--- a/WrenchCL/WrenchLogger.py
+++ b/WrenchCL/WrenchLogger.py
@@ -269,7 +269,7 @@ class _wrench_logger:
         """Check if the frame is internal or not relevant (e.g., logging, wrenchlogger, __init__.py, or custom patterns)."""
         normalized_filepath = os.path.normcase(filepath)
         return ('\\logging\\' in normalized_filepath or
-                '\\wrenchlogger.py' in normalized_filepath or
+                '\\WrenchLogger.py' in normalized_filepath or
                 normalized_filepath.endswith('__init__.py') or
                 'pycaller' in normalized_filepath)
 


### PR DESCRIPTION
Changed the case of the filename in the filepath check within WrenchLogger.py from lowercase to proper case. This adjustment ensures that the filepath checking function correctly identifies its own file, maintaining functionality across case-sensitive systems.