### PR TITLE
Add AWS deployment configuration to SSH tunnel

### DIFF
--- a/WrenchCL/Connect/AwsClientHub.py
+++ b/WrenchCL/Connect/AwsClientHub.py
@@ -252,7 +252,7 @@ class AwsClientHub:
             if self.secret_string is None:
                 raise ValueError(f"Invalid secret string found {self.secret_string}")
 
-            if self.config.qa_host_check in self.secret_string['host']:
+            if self.config.qa_host_check in self.secret_string['host'] and not self.config.aws_deployment:
                 self.need_ssh_tunnel = True
 
         except Exception as e:

--- a/WrenchCL/_Internal/_ConfigurationManager.py
+++ b/WrenchCL/_Internal/_ConfigurationManager.py
@@ -35,11 +35,12 @@ class _ConfigurationManager:
         openai_api_key (str): API key for OpenAI.
         ssh_server (str): SSH server address.
         ssh_port (int): SSH server port.
-        ssh_user (str): SSH user name.
+        ssh_user (str): SSH username.
         ssh_password (str): SSH user password.
         pem_path (str): Path to the PEM file for SSH authentication.
         qa_host_check (str): Host check identifier for QA environment.
         db_batch_size (int): Batch size for database operations.
+        aws_deployment (bool): Override for ssh tunnel on QA (when actively deployed on aws shh tunnel is off)
     """
 
     def __init__(self, env_path=None, **kwargs):
@@ -65,6 +66,7 @@ class _ConfigurationManager:
         self.pem_path = None
         self.qa_host_check = 'ce5sivkxtgbs'
         self.db_batch_size = 10000
+        self.aws_deployment = None
 
         try:
             self._initialize_env()
@@ -145,6 +147,7 @@ class _ConfigurationManager:
         self.ssh_password = kwargs.get('SSH_PASSWORD', self.ssh_password)
         self.pem_path = kwargs.get('PEM_PATH', self.pem_path)
         self.db_batch_size = int(kwargs.get('DB_BATCH_OVERRIDE', self.db_batch_size or 10000))
+        self.aws_deployment = str(kwargs.get('AWS_DEPLOYMENT', self.aws_deployment)).lower() == 'true'
 
     def _init_from_env(self):
         """
@@ -160,3 +163,4 @@ class _ConfigurationManager:
         self.ssh_password = os.getenv('SSH_PASSWORD', self.ssh_password)
         self.pem_path = os.getenv('PEM_PATH', self.pem_path)
         self.db_batch_size = int(os.getenv('DB_BATCH_OVERRIDE', self.db_batch_size or 10000))
+        self.aws_deployment = str(os.getenv('DB_BATCH_OVERRIDE', None)).lower() == 'true'


### PR DESCRIPTION
Enabled AWS deployment support by introducing 'aws_deployment' flag in the ConfigurationManager. If the 'aws_deployment' flag is true, the SSH tunnel connection won't be used even when the qa_host_check is in the secret string. This flag can be configured with environment variables or kwargs for more flexible deployment scenarios.