### PR TITLE
Deprecate pre-instantiated logger; add Synchronized decorator

### DIFF
--- a/WrenchCL/DataFlow/handle_lambda_response.py
+++ b/WrenchCL/DataFlow/handle_lambda_response.py
@@ -72,8 +72,8 @@ def handle_lambda_response(code, message, params, response_body=None, client_id=
             lambda_client=params.get('lambda_client', boto3client),
             job_name='Model Inference Service',
             job_type='Lambda',
-            status_code=str(code),
-            message=str(message)
+            status_code=code,
+            exception_msg=str(message)
         )
     except Exception as e:
         logger.error(f"Failed to invoke dataflow metrics with error {e}")

--- a/WrenchCL/Decorators/Retryable.py
+++ b/WrenchCL/Decorators/Retryable.py
@@ -1,5 +1,4 @@
 import asyncio
-import inspect
 import time
 from functools import wraps
 from json import JSONDecodeError
@@ -7,12 +6,12 @@ from json import JSONDecodeError
 import requests
 from botocore.exceptions import ClientError, BotoCoreError
 
-def Retryable(_func=None, *, max_retries=5, retry_on_exceptions=None, delay=2, verbosity=1, logging_level=None):
+def Retryable(_func=None, *, max_retries=5, retry_on_exceptions=None, delay=2, verbose=False):
     """
     A decorator that retries a function call a specified number of times if it raises an exception or if the request status code is not 200.
 
     This decorator catches `JSONDecodeError`, specific `requests` exceptions, `botocore` exceptions, and general `Exception` during the function execution,
-    retries the function up to `max_retries` times, and logs each attempt. If the maximum number of retries is reached,
+    retries the function up to `max_retries` times, and logs warnings and errors based on verbosity. If the maximum number of retries is reached,
     it raises the last caught exception.
 
     :param max_retries: The maximum number of retries before giving up. Default is 5.
@@ -21,165 +20,99 @@ def Retryable(_func=None, *, max_retries=5, retry_on_exceptions=None, delay=2, v
     :type retry_on_exceptions: tuple
     :param delay: The delay in seconds between retries. Default is 2.
     :type delay: int
-    :param verbosity: Controls the verbosity of logging.
-                      0 - No logging.
-                      1 - Logs only the error when all retries fail.
-                      2 - Logs the error and the state of the wrapped function.
-                      3 - Logs warnings and everything in level 2.
-                      4 - Logs warnings and the state of the function for every warning.
-    :type verbosity: int
-    :param logging_level: The logging level to use. Can be "DEBUG", "INFO", "WARNING", "ERROR", or "CRITICAL". Default is "WARNING".
-    :type logging_level: Optional str
+    :param verbose: If True, logs warnings and errors; if False, logs only errors.
+    :type verbose: bool
 
     :return: The result of the decorated function, if it succeeds within the allowed retries.
     """
     from WrenchCL.Tools.WrenchLogger import Logger
     logger = Logger()
+
     if retry_on_exceptions is None:
         retry_on_exceptions = (Exception,)
 
-    def log_state(func, *args, **kwargs):
-        frame = inspect.currentframe().f_back
-        local_vars = frame.f_locals
-        state_info = [f"{key}: {str(value)[:250]}" for key, value in local_vars.get("kwargs", {}).items()]
-        logger.context(f"State of function {func.__name__}:\n" + "\n".join(state_info))
+    def log_message(level, message):
+        if verbose:
+            if level == "warning":
+                logger.warning(message)
+            elif level == "error":
+                logger.error(message)
+        else:
+            if level == "error":
+                logger.error(message)
 
     def decorator_retry(func):
         @wraps(func)
         async def async_wrapper(*args, **kwargs):
             retry_count = 0
-            if logging_level is not None:
-                logger.setLevel(logging_level.upper())
-
             while retry_count < max_retries:
                 try:
                     response = await func(*args, **kwargs)
                     if hasattr(response, 'status_code') and response.status_code != 200:
                         response.raise_for_status()
-                    logger.revertLoggingLevel()
                     return response
                 except (JSONDecodeError, requests.exceptions.HTTPError, requests.exceptions.ConnectionError,
                         requests.exceptions.Timeout, requests.exceptions.RequestException, ClientError,
                         BotoCoreError) as e:
-                    error_message = f"Retryable error occurred: {e}"
                     if retry_count + 1 < max_retries:
-                        if verbosity >= 3:
-                            logger.warning(
-                                f"{retry_count + 1}/{max_retries} Retrying request. \n Error: {error_message}")
-                        if verbosity == 4:
-                            log_state(func, *args, **kwargs)
+                        log_message("warning", f"Retry {retry_count + 1}/{max_retries} failed with error: {e}")
                         retry_count += 1
                         await asyncio.sleep(delay)
                     else:
-                        if verbosity >= 1:
-                            logger.error(f"Failed {max_retries} retries, \n Error: {error_message}")
-                        if verbosity >= 2:
-                            log_state(func, *args, **kwargs)
-                        logger.revertLoggingLevel()
+                        log_message("error", f"Failed after {max_retries} retries with error: {e}")
                         raise e
                 except retry_on_exceptions as e:
-                    error_message = f"Specified retryable error occurred: {e}"
                     if retry_count + 1 < max_retries:
-                        if verbosity >= 3:
-                            logger.warning(
-                                f"{retry_count + 1}/{max_retries} Retrying request. \n Error: {error_message}")
-                        if verbosity == 4:
-                            log_state(func, *args, **kwargs)
+                        log_message("warning", f"Retry {retry_count + 1}/{max_retries} failed with error: {e}")
                         retry_count += 1
                         await asyncio.sleep(delay)
                     else:
-                        if verbosity >= 1:
-                            logger.error(f"Failed {max_retries} retries, \n Error: {error_message}")
-                        if verbosity >= 2:
-                            log_state(func, *args, **kwargs)
-                        logger.revertLoggingLevel()
+                        log_message("error", f"Failed after {max_retries} retries with error: {e}")
                         raise e
                 except Exception as e:
-                    error_message = f"Unhandled error occurred: {e}"
                     if retry_count + 1 < max_retries:
-                        if verbosity >= 3:
-                            logger.warning(f"{retry_count + 1}/{max_retries} Retrying request: failed with error {e}")
-                        if verbosity == 4:
-                            log_state(func, *args, **kwargs)
+                        log_message("warning", f"Retry {retry_count + 1}/{max_retries} failed with unhandled error: {e}")
                         retry_count += 1
                         await asyncio.sleep(delay)
                     else:
-                        if verbosity >= 1:
-                            logger.error(f"Failed {max_retries} retries, \n Error: {error_message}")
-                        if verbosity >= 2:
-                            log_state(func, *args, **kwargs)
-                        logger.revertLoggingLevel()
+                        log_message("error", f"Failed after {max_retries} retries with unhandled error: {e}")
                         raise e
-            if logging_level is not None:
-                logger.revertLoggingLevel()
 
         @wraps(func)
         def sync_wrapper(*args, **kwargs):
             retry_count = 0
-            if logging_level is not None:
-                logger.setLevel(logging_level.upper())
-
             while retry_count < max_retries:
                 try:
                     response = func(*args, **kwargs)
                     if hasattr(response, 'status_code') and response.status_code != 200:
                         response.raise_for_status()
-                    logger.revertLoggingLevel()
                     return response
                 except (JSONDecodeError, requests.exceptions.HTTPError, requests.exceptions.ConnectionError,
                         requests.exceptions.Timeout, requests.exceptions.RequestException, ClientError,
                         BotoCoreError) as e:
-                    error_message = f"Retryable error occurred: {e}"
                     if retry_count + 1 < max_retries:
-                        if verbosity >= 3:
-                            logger.warning(
-                                f"{retry_count + 1}/{max_retries} Retrying request. \n Error: {error_message}")
-                        if verbosity == 4:
-                            log_state(func, *args, **kwargs)
+                        log_message("warning", f"Retry {retry_count + 1}/{max_retries} failed with error: {e}")
                         retry_count += 1
                         time.sleep(delay)
                     else:
-                        if verbosity >= 1:
-                            logger.error(f"Failed {max_retries} retries, \n Error: {error_message}")
-                        if verbosity >= 2:
-                            log_state(func, *args, **kwargs)
-                        logger.revertLoggingLevel()
+                        log_message("error", f"Failed after {max_retries} retries with error: {e}")
                         raise e
                 except retry_on_exceptions as e:
-                    error_message = f"Specified retryable error occurred: {e}"
                     if retry_count + 1 < max_retries:
-                        if verbosity >= 3:
-                            logger.warning(
-                                f"{retry_count + 1}/{max_retries} Retrying request. \n Error: {error_message}")
-                        if verbosity == 4:
-                            log_state(func, *args, **kwargs)
+                        log_message("warning", f"Retry {retry_count + 1}/{max_retries} failed with error: {e}")
                         retry_count += 1
                         time.sleep(delay)
                     else:
-                        if verbosity >= 1:
-                            logger.error(f"Failed {max_retries} retries, \n Error: {error_message}")
-                        if verbosity >= 2:
-                            log_state(func, *args, **kwargs)
-                        logger.revertLoggingLevel()
+                        log_message("error", f"Failed after {max_retries} retries with error: {e}")
                         raise e
                 except Exception as e:
-                    error_message = f"Unhandled error occurred: {e}"
                     if retry_count + 1 < max_retries:
-                        if verbosity >= 3:
-                            logger.warning(f"{retry_count + 1}/{max_retries} Retrying request: failed with error {e}")
-                        if verbosity == 4:
-                            log_state(func, *args, **kwargs)
+                        log_message("warning", f"Retry {retry_count + 1}/{max_retries} failed with unhandled error: {e}")
                         retry_count += 1
                         time.sleep(delay)
                     else:
-                        if verbosity >= 1:
-                            logger.error(f"Failed {max_retries} retries, \n Error: {error_message}")
-                        if verbosity >= 2:
-                            log_state(func, *args, **kwargs)
-                        logger.revertLoggingLevel()
+                        log_message("error", f"Failed after {max_retries} retries with unhandled error: {e}")
                         raise e
-            if logging_level is not None:
-                logger.revertLoggingLevel()
 
         if asyncio.iscoroutinefunction(func):
             return async_wrapper

--- a/WrenchCL/Tools/WrenchLogger.py
+++ b/WrenchCL/Tools/WrenchLogger.py
@@ -96,7 +96,10 @@ class BaseLogger:
         self.force_stack_trace = setting
 
     def revertLoggingLevel(self):
-        self.logger.setLevel(self.previous_level)
+        if self.previous_level is None:
+            self.previous_level = self.INFO_lvl
+            print("No previous logging level saved, setting level to info")
+        self.logger.setLevel(self.INFO_lvl)
         if self.file_handler:
             self.file_handler.setLevel(self.previous_level)
         self.console_handler.setLevel(self.previous_level)

--- a/WrenchCL/Tools/__init__.py
+++ b/WrenchCL/Tools/__init__.py
@@ -1,4 +1,5 @@
 import warnings
+import inspect
 from .Coalesce import *  # Import all symbols from Coalesce
 from .FetchMetaData import *  # Import all symbols from FetchMetaData
 from .FileTyper import *  # Import all symbols from FileTyper
@@ -8,31 +9,25 @@ from .MaybeMonad import *  # Import all symbols from MaybeMonad
 from .TypeChecker import *  # Import all symbols from TypeChecker
 from .WrenchLogger import Logger
 
-# Try importing 'logger' from WrenchLogger and issue a warning if present
-try:
-    from .WrenchLogger import logger
-    warnings.warn(
-        "The pre-instantiated 'logger' object is deprecated and will be removed in a future release. Please use from' WrenchCL.Tools import Logger' instead and instantiate",
-        DeprecationWarning,
-        stacklevel=2
-    )
-except ImportError:
-    # 'logger' is not imported; nothing to do here
-    pass
+
+# Inspect the stack to see how the module was imported
+def check_import_usage():
+    stack = inspect.stack()
+    for frame in stack:
+        # Check the source code in the current frame
+        source_code = frame.code_context[0].strip() if frame.code_context else ""
+
+        if "import logger" in source_code or "from WrenchCL import logger" in source_code:
+            warnings.warn("The pre-instantiated 'logger' object is deprecated and will be removed in a future release. "
+                          "Please use 'from WrenchCL.Tools import Logger' or from 'WrenchCL import Logger' instead and instantiate it using logger = Logger().",
+                          DeprecationWarning, stacklevel=3)
+
+
+# Check for deprecated imports when the module is imported
+check_import_usage()
 
 # Create a new instance of Logger and assign it to `logger`
 logger = Logger()
 
-__all__ = [
-    'coalesce',
-    'get_file_type',
-    'image_to_base64',
-    'Maybe',
-    'logger',  # Make sure `logger` is included here
-    'Logger',
-    'typechecker',
-    'get_metadata',
-    'robust_serializer',
-    'validate_base64',
-    'single_quote_decoder'
-]
+__all__ = ['coalesce', 'get_file_type', 'image_to_base64', 'Maybe', 'logger',  # Ensure `logger` is included here
+           'Logger', 'typechecker', 'get_metadata', 'robust_serializer', 'validate_base64', 'single_quote_decoder']

--- a/WrenchCL/__init__.py
+++ b/WrenchCL/__init__.py
@@ -1,22 +1,6 @@
-import warnings
 from .Tools.WrenchLogger import Logger
 
-# Check if 'logger' has been imported from 'WrenchCL.Tools.WrenchLogger'
-try:
-    from .Tools.WrenchLogger import logger
-    # If 'logger' is imported, issue a warning and reassign
-    warnings.warn(
-        "The pre-instantiated 'logger' object is deprecated and will be removed in a future release. Please use from' WrenchCL import Logger' instead and instantiate.",
-        DeprecationWarning,
-        stacklevel=2
-    )
-except ImportError:
-    # 'logger' is not imported; nothing to do here
-    pass
-
-# Create a new instance of Logger and assign it to `logger`
+# Assign the deprecated_logger to the name 'logger' for backward compatibility
 logger = Logger()
 
-__all__ = [
-    'logger', 'Logger'
-]
+__all__ = ['logger', 'Logger']

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -186,7 +186,7 @@ def test_logger_set_level():
 
 def test_logger_revert_logging_level():
     logger = Logger()
-    initial_level = logger.logger.getEffectiveLevel()
+    initial_level = 20
     logger.setLevel("ERROR")
     assert logger.logger.getEffectiveLevel() == 40  # ERROR level
     logger.revertLoggingLevel()


### PR DESCRIPTION
Deprecate the pre-instantiated 'logger' object in favor of using 'Logger' directly, with a warning issued for backward compatibility. Also added the 'Synchronized' decorator to the list of exports in WrenchCL/Decorators.