### PR TITLE
Removing turtledemo

### DIFF
--- a/WrenchCL/Tools/WrenchLogger.py
+++ b/WrenchCL/Tools/WrenchLogger.py
@@ -11,7 +11,6 @@ from datetime import datetime, timedelta, date
 from decimal import Decimal
 from inspect import currentframe
 from textwrap import fill
-from turtledemo.nim import COLOR
 from typing import Any, Optional, Union
 
 from .._Internal._MockPandas import MockPandas


### PR DESCRIPTION
`turtledemo.nim` seems to cause issues on AWS Lambda.

It doesn't look like this module is actively used in code. I don't know how to test this change.

## Details

AWS Lambda raised:
```
Runtime.ImportModuleError: Unable to import module 'lambda_function': No module named '_tkinter'
Traceback (most recent call last):
Error Type: Runtime.ImportModuleError
```

I ran this script locally.
```
import traceback
for module in ["pandas", "numpy", "langchain", "WrenchCL"]:
    try:
        __import__(module)
        print(f"{module} imported successfully.")
    except ImportError as e:
        print(f"Failed to import {module}: {str(e)}")
        traceback.print_exc()
```

It raised,
```
Failed to import WrenchCL: dlopen(/Users/jeongwookim/.pyenv/versions/3.11.6/lib/python3.11/lib-dynload/_tkinter.cpython-311-darwin.so, 0x0002): Library not loaded: /opt/homebrew/opt/tcl-tk/lib/libtk8.6.dylib
  Referenced from: <C2EF994C-F25E-36F6-9625-E0ADC5A46892> /Users/jeongwookim/.pyenv/versions/3.11.6/lib/python3.11/lib-dynload/_tkinter.cpython-311-darwin.so
  Reason: tried: '/opt/homebrew/opt/tcl-tk/lib/libtk8.6.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/tcl-tk/lib/libtk8.6.dylib' (no such file), '/opt/homebrew/opt/tcl-tk/lib/libtk8.6.dylib' (no such file), '/usr/local/lib/libtk8.6.dylib' (no such file), '/usr/lib/libtk8.6.dylib' (no such file, not in dyld cache), '/opt/homebrew/Cellar/tcl-tk/9.0.0_1/lib/libtk8.6.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/tcl-tk/9.0.0_1/lib/libtk8.6.dylib' (no such file), '/opt/homebrew/Cellar/tcl-tk/9.0.0_1/lib/libtk8.6.dylib' (no such file), '/usr/local/lib/libtk8.6.dylib' (no such file), '/usr/lib/libtk8.6.dylib' (no such file, not in dyld cache)
Traceback (most recent call last):
  File "/Users/jeongwookim/Documents/GitHub/generate-content/dependencies-test.py", line 4, in <module>
    __import__(module)
  File "/Users/jeongwookim/Documents/wrenchai/envs/generate-content-v12112024/lib/python3.11/site-packages/WrenchCL/__init__.py", line 1, in <module>
    from .Tools.WrenchLogger import Logger
  File "/Users/jeongwookim/Documents/wrenchai/envs/generate-content-v12112024/lib/python3.11/site-packages/WrenchCL/Tools/__init__.py", line 3, in <module>
    from .WrenchLogger import Logger
  File "/Users/jeongwookim/Documents/wrenchai/envs/generate-content-v12112024/lib/python3.11/site-packages/WrenchCL/Tools/WrenchLogger.py", line 14, in <module>
    from turtledemo.nim import COLOR
  File "/Users/jeongwookim/.pyenv/versions/3.11.6/lib/python3.11/turtledemo/nim.py", line 13, in <module>
    import turtle
  File "/Users/jeongwookim/.pyenv/versions/3.11.6/lib/python3.11/turtle.py", line 107, in <module>
    import tkinter as TK
  File "/Users/jeongwookim/.pyenv/versions/3.11.6/lib/python3.11/tkinter/__init__.py", line 38, in <module>
    import _tkinter # If this fails your Python may not be configured for Tk
    ^^^^^^^^^^^^^^^
ImportError: dlopen(/Users/jeongwookim/.pyenv/versions/3.11.6/lib/python3.11/lib-dynload/_tkinter.cpython-311-darwin.so, 0x0002): Library not loaded: /opt/homebrew/opt/tcl-tk/lib/libtk8.6.dylib
  Referenced from: <C2EF994C-F25E-36F6-9625-E0ADC5A46892> /Users/jeongwookim/.pyenv/versions/3.11.6/lib/python3.11/lib-dynload/_tkinter.cpython-311-darwin.so
  Reason: tried: '/opt/homebrew/opt/tcl-tk/lib/libtk8.6.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/tcl-tk/lib/libtk8.6.dylib' (no such file), '/opt/homebrew/opt/tcl-tk/lib/libtk8.6.dylib' (no such file), '/usr/local/lib/libtk8.6.dylib' (no such file), '/usr/lib/libtk8.6.dylib' (no such file, not in dyld cache), '/opt/homebrew/Cellar/tcl-tk/9.0.0_1/lib/libtk8.6.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/tcl-tk/9.0.0_1/lib/libtk8.6.dylib' (no such file), '/opt/homebrew/Cellar/tcl-tk/9.0.0_1/lib/libtk8.6.dylib' (no such file), '/usr/local/lib/libtk8.6.dylib' (no such file), '/usr/lib/libtk8.6.dylib' (no such file, not in dyld cache)
  ```