### PR TITLE
Add JSON parsing utility and tests; deprecate `build_return_json`.

### DIFF
--- a/WrenchCL/DataFlow/build_return_json.py
+++ b/WrenchCL/DataFlow/build_return_json.py
@@ -21,6 +21,7 @@
 
 
 import json
+import warnings
 from typing import Any, Dict, Optional
 
 from ..Tools import robust_serializer
@@ -47,6 +48,7 @@ def build_return_json(
         dict: The full response object with headers, status code, and body.
     """
     # Default headers
+    warnings.deprecated("build_return_json is deprecated and will be removed in a future release, use please refrain from using", DeprecationWarning)
     default_headers = {
         'Content-Type': 'application/json; charset=utf-8',
         'strict-transport-security': 'max-age=63072000; includeSubdomains; preload',

--- a/WrenchCL/Tools/JsonParser.py
+++ b/WrenchCL/Tools/JsonParser.py
@@ -1,0 +1,250 @@
+#  Copyright (c) $YEAR$. Copyright (c) $YEAR$ Wrench.AI., Willem van der Schans, Jeong Kim
+#
+#  MIT License
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+#  All works within the Software are owned by their respective creators and are distributed by Wrench.AI.
+#
+#  For inquiries, please contact Willem van der Schans through the official Wrench.AI channels or directly via GitHub at [Kydoimos97](https://github.com/Kydoimos97).
+#
+
+import json
+from typing import Union, Any
+from . import logger
+
+
+def parse_json(response: Union[str, dict], max_depth: int = 25, verbose = False) -> dict:
+    """
+    Entry point to parse a JSON response into a Python dictionary. Handles nested JSON structures
+    and enforces a maximum recursion depth.
+
+    Parameters
+    ----------
+    response : Union[str, dict]
+        The JSON response to parse. Can be a dictionary or a JSON-encoded string.
+    max_depth : int, optional
+        Maximum allowed recursion depth to prevent infinite loops (default is 25).
+    verbose : bool, optional
+        If True, logs information messages for key parsing. Otherwise, logs debug messages (default is False).
+
+    Returns
+    -------
+    dict
+        Parsed JSON response as a Python dictionary.
+
+    Raises
+    ------
+    RecursionError
+        If the maximum recursion depth is exceeded.
+    TypeError
+        If the response cannot be parsed into a dictionary.
+    ValueError
+        If the JSON is invalid.
+    json.JSONDecodeError
+        If the JSON decoding fails.
+
+    Notes
+    -----
+    This function calls `recur_parse_json` to handle nested structures and uses `safe_json_loader`
+    to handle malformed JSON gracefully.
+    """
+    try:
+        logger.debug(f"Starting JSON parsing. Max depth: {max_depth}")
+        return recur_parse_json(response, max_depth=max_depth, verbose = verbose)
+    except RecursionError as e:
+        logger.error(f"Recursion limit reached: {e}", stack_info=False)
+        raise
+    except (TypeError, ValueError, json.JSONDecodeError) as e:
+        logger.error(f"Invalid input format: {e}")
+        raise
+    except Exception as e:
+        logger.error(f"Unexpected error in parse_json: {e}")
+        raise
+
+
+def recur_parse_json(d: Union[dict, str], depth: int = 0, max_depth: int = 25, verbose = False) -> dict:
+    """
+    Recursively parses nested JSON structures into a dictionary while enforcing a recursion depth limit.
+
+    Parameters
+    ----------
+    d : Union[dict, str]
+        The current JSON object or string to parse.
+    depth : int, optional
+        Current recursion depth (default is 0).
+    max_depth : int, optional
+        Maximum allowed recursion depth to prevent infinite loops (default is 25).
+    verbose : bool, optional
+        If True, logs parsed keys as information messages. Otherwise, logs them as debug messages (default is False).
+
+    Returns
+    -------
+    dict
+        Fully parsed JSON object.
+
+    Raises
+    ------
+    RecursionError
+        If the maximum recursion depth is exceeded.
+    TypeError
+        If the object cannot be parsed into a dictionary.
+
+    Notes
+    -----
+    This function calls `safe_json_loader` for parsing strings and `list_loader` for handling lists.
+    """
+    if depth > max_depth:
+        raise RecursionError(f"Maximum recursion depth of {max_depth} exceeded")
+
+    d = safe_json_loader(d, raise_error=True)
+
+    if not isinstance(d, dict):
+        raise TypeError(f"Expected dictionary but got {type(d).__name__}")
+
+    for k, v in d.items():
+        if isinstance(v, dict):
+            d[k] = recur_parse_json(v, depth=depth + 1, max_depth=max_depth)
+        elif isinstance(v, str):
+            parsed = safe_json_loader(v, raise_error=False)
+            if isinstance(parsed, dict):
+                d[k] = recur_parse_json(parsed, depth=depth + 1, max_depth=max_depth)
+            elif isinstance(parsed, list):
+                d[k] = list_loader(parsed, depth=depth + 1, max_depth=max_depth, verbose = verbose)
+            else:
+                d[k] = parsed
+        elif isinstance(v, list):
+            d[k] = list_loader(v, depth=depth + 1, max_depth=max_depth, verbose = verbose)
+        indent = "--" * (depth + 1)
+        if verbose:
+            logger.info(f"{indent}>Parsed key '{k}': to type {type(d[k]).__name__}")
+        else:
+            logger.debug(f"{indent}>Parsed key '{k}': to type {type(d[k]).__name__}")
+    return d
+
+
+def list_loader(v: Any, depth: int = 0, max_depth: int = 25, verbose = False) -> list:
+    """
+    Recursively parses lists within a JSON structure. Handles both valid and malformed JSON strings.
+
+    Parameters
+    ----------
+    v : Any
+        The list to process. Elements can be dictionaries, JSON strings, or other data types.
+    depth : int, optional
+        Current recursion depth (default is 0).
+    max_depth : int, optional
+        Maximum allowed recursion depth to prevent infinite loops (default is 25).
+    verbose : bool, optional
+        If True, logs parsed list elements as information messages. Otherwise, logs them as debug messages (default is False).
+
+    Returns
+    -------
+    list
+        Fully parsed list with nested structures resolved.
+
+    Raises
+    ------
+    RecursionError
+        If the maximum recursion depth is exceeded.
+    TypeError
+        If the input is not a list.
+
+    Notes
+    -----
+    The function calls `safe_json_loader` for string parsing and `recur_parse_json` for dictionary parsing.
+    """
+    if depth > max_depth:
+        raise RecursionError(f"Maximum recursion depth of {max_depth} exceeded in list_loader")
+
+    if not isinstance(v, list):
+        raise TypeError(f"Expected list but got {type(v).__name__}")
+
+    parsed_list = []
+    for item in v:
+        if isinstance(item, dict):
+            parsed_list.append(recur_parse_json(item, depth=depth + 1, max_depth=max_depth, verbose = verbose))
+        elif isinstance(item, str):
+            parsed = safe_json_loader(item, raise_error=False)
+            if isinstance(parsed, dict):
+                parsed_list.append(recur_parse_json(parsed, depth=depth + 1, max_depth=max_depth, verbose = verbose))
+            elif isinstance(parsed, list):
+                parsed_list.append(list_loader(parsed, depth=depth + 1, max_depth=max_depth, verbose = verbose))
+            else:
+                parsed_list.append(parsed)
+        else:
+            parsed_list.append(item)
+
+    return parsed_list
+
+
+def safe_json_loader(content: Any, raise_error=False, depth=0, silent = False) -> Union[dict, str, Any]:
+    """
+    Safely parses JSON strings into Python dictionaries or leaves them as-is if they are malformed.
+
+    Parameters
+    ----------
+    content : Any
+        The content to parse. Expected to be a JSON string, dictionary, or list.
+    raise_error : bool, optional
+        If True, raises exceptions for JSON parsing errors. Otherwise, leaves malformed strings as-is (default is False).
+    depth : int, optional
+        Current recursion depth, used for logging indentation (default is 0).
+    silent : bool, optional
+        If True, suppresses warnings for malformed JSON (default is False).
+
+    Returns
+    -------
+    Union[dict, str, Any]
+        Parsed JSON object, string, or the original content if parsing fails.
+
+    Raises
+    ------
+    json.JSONDecodeError
+        If JSON decoding fails and `raise_error` is True.
+    TypeError
+        If the content is not a string, dictionary, or list.
+
+    Notes
+    -----
+    - Properly handles nested structures by recursively calling itself for strings within dictionaries.
+    - Logs warnings for malformed JSON strings unless `silent` is True.
+    """
+
+    if isinstance(content, dict):
+        return content  # Already a valid dictionary
+
+    if isinstance(content, str):
+        try:
+            parsed = json.loads(content.strip())  # Try parsing the whole string
+            if isinstance(parsed, dict):
+                for key, value in parsed.items():
+                    if isinstance(value, str):
+                        try:
+                            parsed[key] = safe_json_loader(value, raise_error=True, depth=depth + 1, silent= True)
+                        except json.JSONDecodeError as e:
+                            indent = "--" * (depth + 2)
+                            if '{' in value or '}' in value:
+                                logger.warning(f"{indent}>Malformed JSON in key '{key}': {value}")
+                            logger.debug(f"{indent}>End of structure at key: {key}, value: {value}'")
+                            return parsed
+                return parsed
+            elif isinstance(parsed, list):
+                return list_loader(parsed)
+            return parsed
+        except json.JSONDecodeError as e:
+            if not silent:
+                indent = "--" * (depth + 1)
+                if '{' in content or '}' in content:
+                    logger.warning(f"{indent}>Malformed JSON in content: {content}")
+                logger.debug(f"{indent}>End of structure at depth: {depth + 1}")
+            if raise_error:
+                raise
+            return content  # Leave malformed content as-is
+
+    raise TypeError(f"safe_json_loader expected string or dict but got {type(content).__name__}")
+

--- a/WrenchCL/Tools/__init__.py
+++ b/WrenchCL/Tools/__init__.py
@@ -31,6 +31,6 @@ from .JsonSerializer import *  # Import all symbols from JsonSerializer
 from .MaybeMonad import *  # Import all symbols from MaybeMonad
 from .TypeChecker import *  # Import all symbols from TypeChecker
 from .StandardizeNone import standardize_none
-
+from .JsonParser import parse_json, safe_json_loader, list_loader
 __all__ = ['coalesce', 'get_file_type', 'image_to_base64', 'Maybe', 'logger',  # Ensure `logger` is included here
-           'Logger', 'typechecker', 'get_metadata', 'robust_serializer', 'validate_base64', 'single_quote_decoder']
+           'Logger', 'typechecker', 'get_metadata', 'robust_serializer', 'validate_base64', 'single_quote_decoder', 'parse_json', 'safe_json_loader', 'list_loader']

--- a/tests/test_jsonparser.py
+++ b/tests/test_jsonparser.py
@@ -1,0 +1,191 @@
+import pytest
+from WrenchCL.Tools import parse_json, safe_json_loader, list_loader, logger
+
+
+@pytest.fixture
+def examples():
+    """
+    Fixture to provide test examples with nested and complex JSON structures.
+    """
+    examples = {
+        "valid_nested_json": {
+            "Payload": '{"status": "ok", "details": "{\\"level1\\": \\"{\\\\\\"level2\\\\\\": \\\\\\"{\\\\\\\\\\\\\\"level3\\\\\\\\\\\\\\": \\\\\\\\\\\\\\"value\\\\\\\\\\\\\\"}\\\\\\"}\\"}"}',
+            "Metadata": {
+                "info": '{"timestamp": "2025-01-28T12:34:56Z", "history": "[{\\"action\\": \\"created\\", \\"time\\": \\"2025-01-28T11:00:00Z\\"}]"}'
+            }
+        },
+        "json_with_list_of_mixed_types": {
+            "Payload": '{"status": "success", "results": "[{\\"id\\": 1, \\"value\\": \\"{\\\\\\"nested\\\\\\": \\\\\\"{\\\\\\\\\\\\\\"key\\\\\\\\\\\\\\": 42}\\\\\\"}\\"}, \\"raw string\\"]"}',
+            "Metadata": {
+                "history": '[{"event": "start", "data": "simple"}, "non-json-string", {"event": "end", "data": "{\\"nested\\": \\"deep\\"}"}]'
+            }
+        },
+        "malformed_json_in_payload": {
+            "Payload": '{"data": "{\\"level1\\": \\"{\\\\\\"level2\\\\\\": \\\\\\"{\\\\\\\\\\\\\\"stream\\\\\\\\\\\\\\": \\\\\\\\\\\\\\"raw text\\\\\\\\\\\\\\"}\\\\\\"}\\"}"}',
+            "Metadata": {
+                "info": '{"timestamp": "2025-01-28T12:34:56Z", "details": "{\\"status\\": \\"malformed\\", \\"data\\": [{\\"key\\": 1}, \\"malformed-string\\"]}"}',
+                "tags": ["simple", '{"complex": "{\\"key\\": \\"value\\"}"}']
+            }
+        },
+        "json_with_list": {
+            "Payload": '[{"id": 1, "data": "{\\"nested\\": \\"{\\\\\\"key\\\\\\": \\\\\\"value\\\\\\"}\\"}"}, {"id": 2, "data": "plain text"}]',
+            "Metadata": '{"history": "[{\\"event\\": \\"start\\"}, {\\"event\\": \\"end\\", \\"data\\": \\"{\\\\\\"nested\\\\\\": \\\\\\"deep\\\\\\"}\\"}]"}'
+        },
+        "recursive_abort": {},  # Cyclic reference set below
+        "malformed_escape": {
+            "Payload": '{"level1": "{\\"level2\\": \\"{\\\\\\"level3\\\\\\": \\\\\\"{\\\\\\\\\\\"key\\\\\\\\\": \\\\\\\\\\\"{\\\\\\\\\\\\\\\\\\\\\\\\"malformed\\\\\\\\\\\\\\\\\\\\\\\\"}\\\\\\\\\\\\"}\\"}\\"}"}',
+            "Metadata": {
+                "data": [
+                    '{"key": "value"}',
+                    '{"malformed_json": "{\\"missing_end"}',
+                    '{"nested_list": "[{\\"key\\": 1}, {\\"key\\": 2}]"}'
+                ]
+            }
+        }
+    }
+
+    # Create a cyclic reference for Example 5
+    example_5 = {}
+    example_5["Payload"] = {"nested": None}  # Initialize as a dictionary
+    example_5["Payload"]["nested"] = example_5["Payload"]
+    examples["recursive_abort"] = example_5
+
+    return examples
+
+@pytest.mark.parametrize("example_name", [
+    "valid_nested_json",
+    "json_with_list_of_mixed_types",
+    "malformed_json_in_payload",
+    "json_with_list",
+    "recursive_abort",
+    "malformed_escape"
+])
+def test_parse_response(example_name, examples, caplog):
+    """
+    Test the parse_response function with various nested and complex examples.
+    """
+    example_data = examples[example_name]
+    logger.setLevel("DEBUG")
+
+    logger.info(f"Processing {example_name}")
+    try:
+        parsed = parse_json(example_data)
+        logger.data(parsed)
+        # Validate the parsed response based on the example
+        if example_name == "valid_nested_json":
+            assert isinstance(parsed, dict)
+            assert "Payload" in parsed
+            assert "Metadata" in parsed
+            assert parsed["Payload"]["status"] == "ok"
+            assert parsed["Payload"]["details"]["level1"]["level2"]["level3"] == "value"
+            assert parsed["Metadata"]["info"]["timestamp"] == "2025-01-28T12:34:56Z"
+            assert parsed["Metadata"]["info"]["history"][0]["action"] == "created"
+
+        elif example_name == "json_with_list_of_mixed_types":
+            assert isinstance(parsed, dict)
+            assert "Payload" in parsed
+            assert "Metadata" in parsed
+            assert parsed["Payload"]["status"] == "success"
+            assert parsed["Payload"]["results"][0]["id"] == 1
+            assert parsed["Payload"]["results"][0]["value"]["nested"]["key"] == 42
+            assert parsed["Metadata"]["history"][0]["event"] == "start"
+            assert parsed["Metadata"]["history"][2]["data"]["nested"] == "deep"
+
+        elif example_name == "malformed_json_in_payload":
+            assert isinstance(parsed, dict)
+            assert "Payload" in parsed
+            assert "Metadata" in parsed
+            assert parsed["Payload"]["data"]["level1"]["level2"]["stream"] == "raw text"
+            assert parsed["Metadata"]["info"]["timestamp"] == "2025-01-28T12:34:56Z"
+            assert parsed["Metadata"]["tags"][1]["complex"]["key"] == "value"
+
+        elif example_name == "json_with_list":
+            assert isinstance(parsed, dict)
+            assert "Payload" in parsed
+            assert "Metadata" in parsed
+            assert parsed["Payload"][0]["id"] == 1
+            assert parsed["Payload"][0]["data"]["nested"]["key"] == "value"
+            assert parsed["Metadata"]["history"][1]["event"] == "end"
+            assert parsed["Metadata"]["history"][1]["data"]["nested"] == "deep"
+
+        elif example_name == "recursive_abort":
+            assert isinstance(parsed, dict)
+            assert "Payload" in parsed
+            assert "nested" in parsed["Payload"]
+            assert parsed["Payload"]["nested"] is parsed["Payload"]  # Cyclic reference check
+
+        elif example_name == "malformed_escape":
+            assert isinstance(parsed, dict)
+            assert "Payload" in parsed
+            assert "Metadata" in parsed
+            assert isinstance(parsed["Payload"], str)
+            assert parsed["Metadata"]["data"][0]["key"] == "value"
+            assert parsed["Metadata"]["data"][1]["malformed_json"] == '{"missing_end'
+            assert parsed["Metadata"]["data"][2]["nested_list"][0]["key"] == 1
+
+        logger.data(parsed)
+    except Exception as e:
+        logger.error(f"Error processing {example_name}: {str(e)}")
+        if example_name == "recursive_abort":
+            assert "Maximum recursion depth" in str(e), f"{example_name} failed for the wrong reason."
+        else:
+            pytest.fail(f"Unexpected error in {example_name}: {str(e)}")
+
+
+def test_safe_json_loader_valid_cases():
+    """
+    Test the safe_json_loader function with valid JSON inputs.
+    """
+    assert safe_json_loader('{"key": "value"}') == {"key": "value"}
+    assert safe_json_loader('[{"key": 1}, {"key": 2}]') == [{"key": 1}, {"key": 2}]
+
+
+def test_safe_json_loader_malformed_cases():
+    """
+    Test the safe_json_loader function with malformed JSON inputs.
+    """
+    assert safe_json_loader('{"key": "value"') == '{"key": "value"'
+    assert safe_json_loader("not a json") == "not a json"
+
+
+def test_list_loader_valid_and_malformed():
+    """
+    Test the list_loader function with mixed valid and malformed inputs.
+    """
+    test_list = [
+        '{"key": 1}',
+        '{"key": "malformed',
+        "not a json",
+        '{"nested": {"key": "value"}}'
+    ]
+    parsed = list_loader(test_list)
+    assert parsed == [
+        {"key": 1},
+        '{"key": "malformed',
+        "not a json",
+        {"nested": {"key": "value"}}
+    ]
+
+
+def test_max_recursion_depth():
+    """
+    Test parse_json for maximum recursion depth handling.
+    """
+    nested_json = '{"key":' + '{"nested":' * 30 + '"value"' + "}" * 30 + "}"
+    with pytest.raises(RecursionError):
+        parse_json(nested_json, max_depth=25)
+
+
+def test_large_json():
+    """
+    Test parse_json with a very large JSON structure.
+    """
+    large_json = {"key": [{"nested": i} for i in range(1000)]}
+    parsed = parse_json(large_json)
+    assert len(parsed["key"]) == 1000
+    assert parsed["key"][0] == {"nested": 0}
+
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
Introduced a new JSON parsing utility (`JsonParser.py`) with methods to handle nested JSON and malformed structures. Added comprehensive tests for edge cases, including recursion depth and malformed JSON. Marked `build_return_json` as deprecated with a warning for future removal.

---

# Test Session Report

---
## Test Results

Collected 39 items:

- **tests/test_imports.py**
  - `test_internal_import`: PASSED [2%]
  - `test_connect_import`: PASSED [5%]
  - `test_dataflow_import`: PASSED [7%]
  - `test_decorators_import`: PASSED [10%]
  - `test_tools_import`: PASSED [12%]
  - `test_logger_import`: PASSED [15%]

- **tests/test_jsonparser.py**
  - `test_parse_response[valid_nested_json]`: PASSED [17%]
  - `test_parse_response[json_with_list_of_mixed_types]`: PASSED [20%]
  - `test_parse_response[malformed_json_in_payload]`: PASSED [23%]
  - `test_parse_response[json_with_list]`: PASSED [25%]
  - `test_parse_response[recursive_abort]`: PASSED [28%]
  - `test_parse_response[malformed_escape]`: PASSED [30%]
  - `test_safe_json_loader_valid_cases`: PASSED [33%]
  - `test_safe_json_loader_malformed_cases`: PASSED [35%]
  - `test_list_loader_valid_and_malformed`: PASSED [38%]
  - `test_max_recursion_depth`: PASSED [41%]
  - `test_large_json`: PASSED [43%]

- **tests/test_tools.py**
  - `test_coalesce`: PASSED [46%]
  - `test_get_metadata`: PASSED [48%]
  - `test_get_file_type`: PASSED [51%]
  - `test_image_to_base64`: PASSED [53%]
  - `test_get_hash`: PASSED [56%]
  - `test_robust_serializer`: PASSED [58%]
  - `test_single_quote_decoder`: PASSED [61%]
  - `test_maybe`: PASSED [64%]
  - `test_typechecker`: PASSED [66%]
  - `test_logger_basic`: PASSED [69%]
  - `test_logger_flow`: PASSED [71%]
  - `test_logger_context`: PASSED [74%]
  - `test_logger_hdl_warn`: PASSED [76%]
  - `test_logger_hdl_err`: PASSED [79%]
  - `test_logger_recv_err`: PASSED [82%]
  - `test_logger_data`: PASSED [84%]
  - `test_logger_time`: PASSED [87%]
  - `test_logger_compact_header`: PASSED [89%]
  - `test_logger_set_level`: PASSED [92%]
  - `test_logger_revert_logging_level`: PASSED [94%]
  - `test_logger_set_global_traceback`: PASSED [97%]
  - `test_logger_verbose_mode`: PASSED [100%]

39 passed in 2.66s

---

## Coverage Report

| File                                            | Stmts | Miss | Cover | Missing                                                   |
|-------------------------------------------------|-------|------|-------|-----------------------------------------------------------|
| WrenchCL\Connect\AwsClientHub.py                 | 218   | 164  | 25%   | 44-49, 93-106, 110-122, 128-133, 146-147, 159-161, 172-180, 193-195, 213-215, 225-227, 237-239, 251, 260-295, 308-324, 333-339, 351-358, 374-395, 412-425, 458-504, 515-517 |
| WrenchCL\Connect\RdsServiceGateway.py            | 170   | 133  | 22%   | 20-21, 45-56, 59-60, 69-71, 80-81, 88-113, 140-226, 240-241, 250-253, 264-267, 274-284, 289-306 |
| WrenchCL\Connect\S3ServiceGateway.py             | 169   | 120  | 29%   | 46-49, 54, 58-66, 69-70, 89-125, 139-143, 157-160, 174-177, 189-192, 208-213, 229-233, 247-260, 274-279, 291-294, 304-308, 325-337, 354-358, 374-378, 394-398 |
| WrenchCL\Connect\__init__.py                     | 4     | 0    | 100%  |                                                           |
| WrenchCL\DataFlow\__init__.py                    | 4     | 0    | 100%  |                                                           |
| WrenchCL\DataFlow\build_return_json.py           | 13    | 8    | 38%   | 51-77                                                    |
| WrenchCL\DataFlow\handle_lambda_response.py      | 34    | 23   | 32%   | 31, 40, 78-146                                            |
| WrenchCL\DataFlow\trigger_dataflow_metrics.py    | 24    | 17   | 29%   | 81-121, 152-159                                           |
| WrenchCL\Decorators\Retryable.py                 | 85    | 65   | 24%   | 35-42, 47-79, 83-115, 118, 125                           |
| WrenchCL\Decorators\SingletonClass.py             | 7     | 0    | 100%  |                                                           |
| WrenchCL\Decorators\Synchronized.py              | 13    | 9    | 31%   | 60-88                                                    |
| WrenchCL\Decorators\TimedMethod.py               | 15    | 13   | 13%   | 40-63                                                    |
| WrenchCL\Decorators\__init__.py                   | 5     | 0    | 100%  |                                                           |
| WrenchCL\Exceptions\__init__.py                  | 33    | 9    | 73%   | 26, 36, 46, 56, 67, 79, 98, 112, 125                     |
| WrenchCL\Tools\Coalesce.py                       | 5     | 0    | 100%  |                                                           |
| WrenchCL\Tools\FetchMetaData.py                  | 21    | 0    | 100%  |                                                           |
| WrenchCL\Tools\FileTyper.py                      | 40    | 22   | 45%   | 47, 53-82                                                |
| WrenchCL\Tools\Image2B64.py                      | 28    | 2    | 93%   | 66-67                                                    |
| WrenchCL\Tools\JsonParser.py                     | 88    | 14   | 84%   | 62-67, 107, 124, 162, 165, 176, 180, 238, 249             |
| WrenchCL\Tools\JsonSerializer.py                 | 43    | 9    | 79%   | 86, 157-168                                              |
| WrenchCL\Tools\MaybeMonad.py                     | 55    | 18   | 67%   | 43-44, 50, 72-84, 93-94, 123                             |
| WrenchCL\Tools\StandardizeNone.py                | 33    | 27   | 18%   | 22-23, 39-53, 66-86                                      |
| WrenchCL\Tools\TypeChecker.py                    | 30    | 14   | 53%   | 64, 72-73, 76, 80-86, 92-94                              |
| WrenchCL\Tools\WrenchLogger.py                   | 367   | 80   | 78%   | 24-29, 33-34, 59, 63, 106-107, 116, 136, 153-154, 157, 167, 262, 279-281, 292, 294, 300-301, 306-327, 330-331, 333-338, 345, 359, 364, 381, 385, 387, 391-393, 403, 419, 425, 440, 442-443, 490-497, 503-507, 544-546, 588, 613 |
| WrenchCL\Tools\__init__.py                       | 20    | 5    | 75%   | 9-15                                                     |
| WrenchCL\_Internal\_ConfigurationManager.py      | 70    | 57   | 19%   | 104-138, 144-146, 157-159, 168-178, 184-194, 203-208      |
| WrenchCL\_Internal\_MockPandas.py                | 34    | 13   | 62%   | 23-24, 28, 32-33, 38, 42, 50, 55, 60, 65, 70, 74           |
| WrenchCL\_Internal\_SshTunnelManager.py          | 30    | 23   | 23%   | 54-69, 78-96, 102-105                                     |
| WrenchCL\_Internal\__init__.py                   | 0     | 0    | 100%  |                                                           |
| WrenchCL\__init__.py                             | 3     | 0    | 100%  |                                                           |
| **tests/test_imports.py**                       | 39    | 15   | 62%   | 8-9, 14-15, 26-27, 32-33, 48-49, 54-55, 59-60, 63          |
| **tests/test_jsonparser.py**                    | 90    | 6    | 93%   | 112-115, 132, 191                                         |
| **tests/test_tools.py**                         | 162   | 3    | 98%   | 238-239, 242                                             |
| TOTAL                                             | 1952| 869 | 55%   |                                              |



