### PR TITLE
bugfix - gate_imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /build/
 /.pytest_cache/
 /Sphinx-docs/
+*.pyc

--- a/WrenchCL/Connect/AwsClientHub.py
+++ b/WrenchCL/Connect/AwsClientHub.py
@@ -61,7 +61,10 @@ class AwsClientHub:
     def _initialize(self, need_secret=False):
         """Load config and secrets if not already initialized."""
         if not self.__initialized:
-            gate_imports(imports, 'aws', ['boto3', 'paramiko', 'psycopg2', '...'])
+            gate_imports(imports, 'aws', ['boto3', 'paramiko', 'psycopg2', '...'], False)
+            if not imports:
+                logger.warning("AWS dependencies not available. AwsClientHub will not be functional.")
+                return
             try:
                 self.reload_config(env_path=self.__env_path, **self.__kwargs)
                 self.__initialized = True

--- a/WrenchCL/Connect/RdsServiceGateway.py
+++ b/WrenchCL/Connect/RdsServiceGateway.py
@@ -55,8 +55,20 @@ class RdsServiceGateway:
         :param max_pool_size: Maximum number of connections in the pool (only if multithreaded is True).
         :type max_pool_size: int
         """
-        gate_imports(imports, 'aws', ['psycopg2'])
-        psycopg2.extras.register_uuid()
+        gate_imports(imports, 'aws', ['psycopg2'], False)
+        if not imports:
+            logger.warning("AWS dependencies not available. RdsServiceGateway will not be functional.")
+            self.multithreaded = multithreaded
+            self.test_mode = False
+            self.client_manager = None
+            self.config = None
+            self.db_uri = None
+            self.pool = None
+            self.connection = None
+            return
+            
+        if psycopg2 is not None:
+            psycopg2.extras.register_uuid()
         self.multithreaded = multithreaded
         self.test_mode = False
         self.client_manager = AwsClientHub()

--- a/WrenchCL/Connect/S3ServiceGateway.py
+++ b/WrenchCL/Connect/S3ServiceGateway.py
@@ -43,7 +43,13 @@ class S3ServiceGateway:
         """
         Initializes the S3ServiceGateway by setting up the S3 client using the AwsClientHub.
         """
-        gate_imports(imports, 'aws', 'botocore')
+        gate_imports(imports, 'aws', 'botocore', False)
+        if not imports:
+            logger.warning("AWS dependencies not available. S3ServiceGateway will not be functional.")
+            self.s3_client = None
+            self.test_mode = False
+            return
+            
         from WrenchCL._Internal._ConfigurationManager import _ConfigurationManager
         state_config: _ConfigurationManager = _ConfigurationManager()
         state_config.initialize(silent=True)

--- a/WrenchCL/Decorators/Retryable.py
+++ b/WrenchCL/Decorators/Retryable.py
@@ -41,9 +41,8 @@ def Retryable(_func=None, *, max_retries=2, retry_on_exceptions=None, delay=2, v
 
     :return: The result of the decorated function, if it succeeds within the allowed retries.
     """
-    gate_imports(imports, 'aws', ['requests', 'botocore'])
+    gate_imports(imports, 'aws', ['requests', 'botocore'], False)
     from WrenchCL.Tools.ccLogBase import logger
-    
 
     if retry_on_exceptions is None:
         retry_on_exceptions = (Exception,)


### PR DESCRIPTION
gate_imports caused errors.

Errors from AiAxis:
```
ai-axis-1  | ERROR   [13:53:09|RDSStateManager.py:init_connection:32] ->
ai-axis-1  | ┌───────────────────────────ERROR───────────────────────────┐
ai-axis-1  |       ImportError: Missing optional dependencies: psycopg2
ai-axis-1  |     Install with: pip install 'WrenchCL[aws]'
ai-axis-1  | └────────────────────────────────────────────────────────────┘
ai-axis-1  | ImportError: Missing optional dependencies: psycopg2
ai-axis-1  | Install with: pip install 'WrenchCL[aws]'
ai-axis-1  | ERROR   [13:53:09|RDSStateManager.py:__init__:23] ->
ai-axis-1  | Failed to initialize RDS connection: Missing optional dependencies: psycopg2
ai-axis-1  | Install with: pip install 'WrenchCL[aws]'
ai-axis-1  | ERROR   [13:53:09|RDSStateManager.py:__init__:26] ->
ai-axis-1  | ┌──────────────────────────────────────ERROR──────────────────────────────────────┐
ai-axis-1  |       ImportError: Missing optional dependencies: boto3, paramiko, psycopg2, ...
ai-axis-1  |     Install with: pip install 'WrenchCL[aws]'
ai-axis-1  | └──────────────────────────────────────────────────────────────────────────────────┘
ai-axis-1  | ImportError: Missing optional dependencies: boto3, paramiko, psycopg2, ...
ai-axis-1  | Install with: pip install 'WrenchCL[aws]'
ai-axis-1  | ERROR   [13:53:11|ServiceManager.py:initialize:97] ->
ai-axis-1  | [SERVICEMANAGER]❌ Initialization failed: Rds: Missing optional dependencies: boto3, paramiko, psycopg2, ...
ai-axis-1  | Install with: pip install 'WrenchCL[aws]'
ai-axis-1  | CRITICAL[13:53:11|APIService.py:init_app:280] ->
ai-axis-1  | Failed to initialize APIService: Rds: Missing optional dependencies: boto3, paramiko, psycopg2, ...
ai-axis-1  | Install with: pip install 'WrenchCL[aws]'
ai-axis-1  | ERROR   [13:53:11|app.py:start_service:50] ->
ai-axis-1  | Stopped Initialization of application: Rds: Missing optional dependencies: boto3, paramiko, psycopg2, ...
ai-axis-1  | Install with: pip install 'WrenchCL[aws]'
ai-axis-1  | Process SpawnProcess-1:
ai-axis-1  | Traceback (most recent call last):
ai-axis-1  |   File "/usr/local/lib/python3.11/multiprocessing/process.py", line 314, in _bootstrap
ai-axis-1  |     self.run()
ai-axis-1  |   File "/usr/local/lib/python3.11/multiprocessing/process.py", line 108, in run
ai-axis-1  |     self._target(*self._args, **self._kwargs)
ai-axis-1  |   File "/usr/local/lib/python3.11/site-packages/uvicorn/_subprocess.py", line 80, in subprocess_started
ai-axis-1  |     target(sockets=sockets)
ai-axis-1  |   File "/usr/local/lib/python3.11/site-packages/uvicorn/server.py", line 67, in run
ai-axis-1  |     return asyncio.run(self.serve(sockets=sockets))
ai-axis-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ai-axis-1  |   File "/usr/local/lib/python3.11/asyncio/runners.py", line 190, in run
ai-axis-1  |     return runner.run(main)
ai-axis-1  |            ^^^^^^^^^^^^^^^^
ai-axis-1  |   File "/usr/local/lib/python3.11/asyncio/runners.py", line 118, in run
ai-axis-1  |     return self._loop.run_until_complete(task)
ai-axis-1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ai-axis-1  |   File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
ai-axis-1  |   File "/usr/local/lib/python3.11/site-packages/uvicorn/server.py", line 71, in serve
ai-axis-1  |     await self._serve(sockets)
ai-axis-1  |   File "/usr/local/lib/python3.11/site-packages/uvicorn/server.py", line 78, in _serve
ai-axis-1  |     config.load()
ai-axis-1  |   File "/usr/local/lib/python3.11/site-packages/uvicorn/config.py", line 442, in load
ai-axis-1  |     self.loaded_app = self.loaded_app()
ai-axis-1  |                       ^^^^^^^^^^^^^^^^^
ai-axis-1  |   File "/app/app.py", line 48, in start_service
ai-axis-1  |     return init_app()
ai-axis-1  |            ^^^^^^^^^^
ai-axis-1  |   File "/app/Api/Factory/APIService.py", line 281, in init_app
ai-axis-1  |     raise e
ai-axis-1  |   File "/app/Api/Factory/APIService.py", line 276, in init_app
ai-axis-1  |     service.initialize_base_app(mcp = True)
ai-axis-1  |   File "/app/Api/Factory/APIService.py", line 56, in initialize_base_app
ai-axis-1  |     self._post_setup_checks()
ai-axis-1  |   File "/app/Api/Factory/APIService.py", line 189, in _post_setup_checks
ai-axis-1  |     GlobalServiceManager.initialize()
ai-axis-1  |   File "/app/Global/Classes/ServiceManager.py", line 98, in initialize
ai-axis-1  |     raise InitializationException(msg)
ai-axis-1  | WrenchCL.Exceptions.Initializations.InitializationException: Rds: Missing optional dependencies: boto3, paramiko, psycopg2, ...
ai-axis-1  | Install with: pip install 'WrenchCL[aws]'
```

This happened when the dependencies were fully installed.