### PR TITLE
DD Trace Injection

### DIFF
--- a/WrenchCL/_Internal/Logging/DatadogTraceInjectionFilter.py
+++ b/WrenchCL/_Internal/Logging/DatadogTraceInjectionFilter.py
@@ -1,0 +1,46 @@
+#  Copyright (c) 2025.
+#  Author: Willem van der Schans.
+#  Licensed under the MIT License (https://opensource.org/license/mit).
+import logging
+from typing import Final, Optional
+
+try:
+    from ddtrace import tracer  # type: ignore
+except Exception:
+    tracer = None  # type: ignore[assignment]
+
+DD_TRACE_ID: Final[str] = "dd.trace_id"
+DD_SPAN_ID:  Final[str] = "dd.span_id"
+_ZERO: Final[str] = "0"
+
+
+class DatadogTraceInjectionFilter(logging.Filter):
+    """
+    Inject Datadog correlation fields into each LogRecord.
+
+    Adds top-level decimal-string fields:
+      - dd.trace_id: current trace id or "0"
+      - dd.span_id:  current span id or "0"
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        # If already populated by another filter or logs injection, keep going.
+        if getattr(record, DD_TRACE_ID, None) is not None and getattr(record, DD_SPAN_ID, None) is not None:
+            return True
+
+        trace_id: str = _ZERO
+        span_id: str = _ZERO
+
+        if tracer is not None:
+            span = tracer.current_span()  # type: Optional[object]
+            if span is not None:
+                tid = getattr(span, "trace_id", None)
+                sid = getattr(span, "span_id", None)
+                if tid is not None:
+                    trace_id = str(tid)
+                if sid is not None:
+                    span_id = str(sid)
+
+        setattr(record, DD_TRACE_ID, trace_id)
+        setattr(record, DD_SPAN_ID, span_id)
+        return True

--- a/WrenchCL/_Internal/Logging/Formatters.py
+++ b/WrenchCL/_Internal/Logging/Formatters.py
@@ -5,6 +5,7 @@ import contextvars
 import json
 import logging
 import os
+from datetime import datetime, timezone
 from typing import Any, Callable, Dict, Optional, Final
 
 from .ColorService import ColorService, ColorPresets, MockColorama
@@ -79,6 +80,10 @@ class JSONLogFormatter(logging.Formatter):
     # ---------- context harvesting (same spirit, preserved) ----------
     @staticmethod
     def _extract_generic_context() -> Dict[str, Any]:
+        """
+        Safely extract recognized context keys (user/org/service) from contextvars,
+        handling both dicts and __dict__-bearing objects, even if cyclic.
+        """
         context_data: Dict[str, Any] = {}
 
         user_keys = {
@@ -86,8 +91,9 @@ class JSONLogFormatter(logging.Formatter):
             "client_id", "user_name", "username",
         }
         org_keys = {"client_id", "org_id", "organization_id", "tenant_id", "team_id", "workspace_id", "project_id"}
-        svc_keys = {"service_id", "service_name", "application", "app_name", "dd_service", "aws_function_name",
-                    "aws_service", "lambda_name", "lambda_function", "aws_function", "project_name", "project"}
+        svc_keys = {"service_id", "service_name", "application", "app_name", "dd_service",
+                    "aws_function_name", "aws_service", "lambda_name", "lambda_function",
+                    "aws_function", "project_name", "project"}
 
         def add(k: str, v: Any) -> None:
             lk = (k or "").lower()
@@ -98,16 +104,68 @@ class JSONLogFormatter(logging.Formatter):
             elif lk in svc_keys:
                 context_data.setdefault("service_name", v)
 
+        visited: set[int] = set()
+
+        def inspect_obj(obj: Any) -> None:
+            """Shallow inspection of dicts or objects with __dict__, avoiding recursion."""
+            obj_id = id(obj)
+            if obj_id in visited:
+                return
+            visited.add(obj_id)
+
+            if isinstance(obj, dict):
+                for k, v in list(obj.items())[:20]:
+                    if id(v) == obj_id:
+                        continue
+                    add(k, v)
+                    if isinstance(v, (dict, object)) and not isinstance(v, (str, int, float, bool, type(None))):
+                        # Shallowly inspect children once
+                        inspect_obj(getattr(v, "__dict__", None) or {})
+            else:
+                d = getattr(obj, "__dict__", None)
+                if isinstance(d, dict):
+                    for k, v in list(d.items())[:20]:
+                        if id(v) == obj_id:
+                            continue
+                        add(k, v)
+                        if isinstance(v, (dict, object)) and not isinstance(v, (str, int, float, bool, type(None))):
+                            inspect_obj(getattr(v, "__dict__", None) or {})
+
         try:
             ctx = contextvars.copy_context()
             for var in ctx:
                 try:
-                    add(var.name, ctx.get(var))
+                    val = ctx.get(var)
+                    inspect_obj(val)
+                except RecursionError:
+                    continue
                 except Exception:
                     continue
         except Exception:
             pass
+
         return context_data
+
+
+
+    def _formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
+        """
+        Formats the record creation time safely.
+
+        Falls back to ISO 8601 UTC timestamp if the given datefmt is invalid.
+        """
+        dt = datetime.fromtimestamp(record.created, tz=timezone.utc)
+
+        # Try the provided format first
+        if datefmt:
+            try:
+                return dt.strftime(datefmt)
+            except ValueError:
+                # Fallback to a portable ISO format
+                return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+        # No datefmt provided → use ISO format
+        return dt.isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
     # ------------------------------- core -------------------------------
     def format(self, record: logging.LogRecord) -> str:
@@ -142,7 +200,7 @@ class JSONLogFormatter(logging.Formatter):
             "module": record.module,
             "function": record.funcName,
             "line": record.lineno,
-            "timestamp": self.formatTime(record, self._TIMEFMT),
+            "timestamp": self._formatTime(record, self._TIMEFMT),
         }
         if self.traced:
             log_record.update({

--- a/WrenchCL/_Internal/Logging/Formatters.py
+++ b/WrenchCL/_Internal/Logging/Formatters.py
@@ -241,7 +241,7 @@ class FileLogFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         raw = self._base_formatter.format(record)
-        from _Internal.Logging.logging_utils import remove_ansi
+        from .logging_utils import remove_ansi
         return remove_ansi(raw)
 
 

--- a/WrenchCL/_Internal/Logging/Formatters.py
+++ b/WrenchCL/_Internal/Logging/Formatters.py
@@ -4,8 +4,8 @@
 import contextvars
 import json
 import logging
-from contextvars import Context
-from typing import Optional, Callable, Dict
+import os
+from typing import Any, Callable, Dict, Optional, Final
 
 from .ColorService import ColorService, ColorPresets, MockColorama
 from .DataClasses import logLevels, LogLevel
@@ -31,7 +31,44 @@ class CustomFormatter(logging.Formatter):
 
 
 class JSONLogFormatter(logging.Formatter):
-    def __init__(self, env_metadata: dict, forced_color: bool, highlight_func: Callable, traced: bool = False, deployed: bool = False):
+    """
+    Datadog-friendly JSON formatter that preserves existing structure and features.
+
+    Top-level fields (for Datadog correlation & triad):
+      - ``service``, ``env``, ``version``
+      - ``dd.trace_id``, ``dd.span_id``
+
+    Preserved blocks:
+      - ``source``: module/function/line (unchanged)
+      - ``log_info``: logger/timestamp (unchanged)
+      - ``context``: harvested hints (unchanged)
+      - ``exception``: formatted tracebacks (unchanged)
+
+    Parameters
+    ----------
+    env_metadata : Dict[str, Optional[str]]
+        Expected keys: ``env``, ``project`` (service), ``project_version``.
+    forced_color : bool
+        If True and not ``deployed``, apply highlight function to the JSON string.
+    highlight_func : Callable[[str], str]
+        Function that colorizes the JSON string for terminals.
+    traced : bool
+        Kept for compatibility; IDs come from a filter, but we still surface them.
+    deployed : bool
+        If True, emit single-line compact JSON (for log routers).
+    """
+
+    # Constants (no behavior change)
+    _TIMEFMT: Final[str] = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+    def __init__(
+        self,
+        env_metadata: Dict[str, Optional[str]],
+        forced_color: bool,
+        highlight_func: Callable[[str], str],
+        traced: bool = False,
+        deployed: bool = False
+    ) -> None:
         super().__init__()
         self.env_metadata = env_metadata
         self.color_mode = forced_color
@@ -39,144 +76,104 @@ class JSONLogFormatter(logging.Formatter):
         self.traced = traced
         self.deployed = deployed
 
+    # ---------- context harvesting (same spirit, preserved) ----------
     @staticmethod
-    def _extract_generic_context() -> dict:
-        """
-        Extract known context values (user_id, organization_id, service_name) from:
-        - os.environ
-        - contextvars
-        - deeply nested dicts or object trees (with cycle protection & depth limit)
-        """
-        context_data: dict = {}
+    def _extract_generic_context() -> Dict[str, Any]:
+        context_data: Dict[str, Any] = {}
 
         user_keys = {
-                "user_id", "usr_id", "entity_id", "user_entity_id", "subject_id",
-                "client_id", "user_name", "username",
-                }
-        org_keys = {
-                "client_id", "org_id", "organization_id", "tenant_id",
-                "team_id", "workspace_id", "project_id",
-                }
-        service_keys = {
-                "service_id", "service_name", "application", "app_name", "dd_service",
-                "aws_function_name", "aws_service", "lambda_name", "lambda_function",
-                "aws_function", "project_name", "project",
-                }
+            "user_id", "usr_id", "entity_id", "user_entity_id", "subject_id",
+            "client_id", "user_name", "username",
+        }
+        org_keys = {"client_id", "org_id", "organization_id", "tenant_id", "team_id", "workspace_id", "project_id"}
+        svc_keys = {"service_id", "service_name", "application", "app_name", "dd_service", "aws_function_name",
+                    "aws_service", "lambda_name", "lambda_function", "aws_function", "project_name", "project"}
 
-        # Prevent infinite recursion on cyclic structures; keep traversal shallow.
-        MAX_DEPTH = 4
-        seen: set[int] = set()
+        def add(k: str, v: Any) -> None:
+            lk = (k or "").lower()
+            if lk in user_keys:
+                context_data.setdefault("user_id", v)
+            elif lk in org_keys:
+                context_data.setdefault("organization_id", v)
+            elif lk in svc_keys:
+                context_data.setdefault("service_name", v)
 
-        def check_keys(key: str, value: object, depth: int) -> dict:
-            result: dict = {}
-            if not isinstance(key, str):
+        try:
+            ctx = contextvars.copy_context()
+            for var in ctx:
                 try:
-                    key = str(key)
+                    add(var.name, ctx.get(var))
                 except Exception:
-                    key = ""
-            k = key.lower()
-
-            if k in user_keys:
-                result["user_id"] = value
-            elif k in org_keys:
-                result["organization_id"] = value
-            elif k in service_keys:
-                result["service_name"] = value
-
-            if depth >= MAX_DEPTH:
-                return result
-
-            try:
-                if isinstance(value, dict):
-                    oid = id(value)
-                    if oid in seen:
-                        return result
-                    seen.add(oid)
-                    result.update(scan_dict(value, depth + 1))
-                elif hasattr(value, "__dict__"):
-                    oid = id(value)
-                    if oid in seen:
-                        return result
-                    seen.add(oid)
-                    try:
-                        result.update(scan_dict(vars(value), depth + 1))
-                    except Exception:
-                        pass
-            except Exception:
-                pass
-
-            return result
-
-        def scan_dict(data: dict, depth: int) -> dict:
-            found: dict = {}
-            try:
-                items = data.items()
-            except Exception:
-                return found
-            for k, v in items:
-                found.update(check_keys(k, v, depth))
-            return found
-
-        def scan_ctx(ctx: "Context") -> dict:
-            found: dict = {}
-            try:
-                for var in ctx:
-                    try:
-                        value = ctx.get(var)
-                    except Exception:
-                        continue
-                    found.update(check_keys(var.name, value, depth=0))
-            except Exception:
-                pass
-            return found
-
-        context_data.update(scan_ctx(contextvars.copy_context()))
+                    continue
+        except Exception:
+            pass
         return context_data
 
+    # ------------------------------- core -------------------------------
     def format(self, record: logging.LogRecord) -> str:
-        ctx = {}
-        dd = {
-                "dd.env": self.env_metadata.get("env"),
-                "dd.service": self.env_metadata.get("project") or ctx.get('service_name'),
-                "dd.version": self.env_metadata.get("project_version")
-                }
-        ctx.update(self._extract_generic_context())
+        # Resolve triad from env_metadata first, then DD_* fallbacks
+        service = (
+            self.env_metadata.get("project")
+            or os.getenv("DD_SERVICE")
+            or os.getenv("PROJECT_NAME")
+            or "unknown-service"
+        )
+        env = (
+            self.env_metadata.get("env")
+            or os.getenv("DD_ENV")
+            or os.getenv("ENV")
+            or "dev"
+        )
+        version = (
+            self.env_metadata.get("project_version")
+            or os.getenv("DD_VERSION")
+            or os.getenv("REPO_VERSION")
+            or "0.0.0"
+        )
 
+        # Correlation IDs injected by DatadogTraceInjectionFilter (decimal strings)
+        dd_trace_id = str(getattr(record, "dd.trace_id", "0"))
+        dd_span_id = str(getattr(record, "dd.span_id", "0"))
+
+        # Base payload — keeps your original structure
+        log_record: Dict[str, Any] = {
+            "level": record.levelname,
+            "message": record.getMessage(),
+            "module": record.module,
+            "function": record.funcName,
+            "line": record.lineno,
+            "timestamp": self.formatTime(record, self._TIMEFMT),
+        }
         if self.traced:
-            dd.update({
-                    "dd.trace_id": str(getattr(record, "dd.trace_id", 0)),
-                    "dd.span_id": str(getattr(record, "dd.span_id", 0))})
+            log_record.update({
+                    "service": service,
+                    "env": env,
+                    "version": version,
+                    "dd.trace_id": dd_trace_id,
+                    "dd.span_id": dd_span_id,
+                    "logger": record.name,
+                    })
 
-        log_record = {
-                "level": record.levelname,
-                "message": record.getMessage(),
-                "source": {
-                        "module": record.module,
-                        "function": record.funcName,
-                        "line": record.lineno,
-                        },
-                "log_info": {
-                        "logger": record.name,
-                        "timestamp": self.formatTime(record, "%Y-%m-%dT%H:%M:%SZ"),
-                        }
-                }
 
-        if dd:
-            log_record['trace'] = dd
+        # Context (preserved)
+        ctx = self._extract_generic_context()
+        if ctx:
+            log_record["context"] = ctx
+
+        # Exceptions (preserved)
         if record.exc_info:
             log_record["exception"] = self.formatException(record.exc_info)
-        if len(ctx) > 0:
-            log_record['context'] = ctx
 
-        if self.deployed:
-            dumped_json = json.dumps(log_record, default=str, ensure_ascii=False)
-        else:
-            dumped_json = json.dumps(log_record, default=str, ensure_ascii=False, indent=2)
+        # Output formatting (preserved behavior)
+        dumped = (
+            json.dumps(log_record, default=str, ensure_ascii=False)
+            if self.deployed
+            else json.dumps(log_record, default=str, ensure_ascii=False, indent=2)
+        )
+        if self.color_mode and not self.deployed:
+            dumped = self.highlight_func(dumped)
+        return dumped
 
-        if self.color_mode is True and not self.deployed:
-            dumped_json = self.highlight_func(dumped_json)
-
-        return dumped_json
 
 
 class FileLogFormatter(logging.Formatter):

--- a/WrenchCL/cLogger.py
+++ b/WrenchCL/cLogger.py
@@ -702,19 +702,33 @@ class cLogger:
                 stacklevel=get_depth(internal=level == 'INTERNAL')
                 )
 
-    def _update_handler_formatters(self, level: LogLevel, no_format: bool, no_color: bool):
-        """Update formatters for the current log operation."""
+    def _update_handler_formatters(self, level: LogLevel, no_format: bool, no_color: bool) -> None:
+        """
+        Update formatters for the current log operation.
+        """
         config = self.state_manager.current_state
         env_metadata = self.state_manager.get_env_metadata()
 
         for handler in self.state_manager.logging_instance.handlers:
-            if not isinstance(handler, logging.NullHandler):
-                formatter = self.state_manager.formatter_factory.create_formatter(
-                        level=level, config_state=config, env_metadata=env_metadata,
-                        global_stream_configured=self.state_manager.global_stream_configured,
-                        no_format=no_format, no_color=no_color
-                        )
-                handler.setFormatter(formatter)
+            if isinstance(handler, logging.NullHandler):
+                continue
+
+            formatter = self.state_manager.formatter_factory.create_formatter(
+                level=level,
+                config_state=config,
+                env_metadata=env_metadata,
+                global_stream_configured=self.state_manager.global_stream_configured,
+                no_format=no_format,
+                no_color=no_color,
+            )
+
+            if self.state_manager.current_state.dd_trace_enabled:
+                # attach once per-handler
+                from _Internal.Logging.DatadogTraceInjectionFilter import DatadogTraceInjectionFilter
+                if not any(isinstance(f, DatadogTraceInjectionFilter) for f in handler.filters):
+                    handler.addFilter(DatadogTraceInjectionFilter())
+
+            handler.setFormatter(formatter)
 
     def _setup_ddtrace(self, trace_enabled: bool):
         """Set up ddtrace if requested."""

--- a/WrenchCL/cLogger.py
+++ b/WrenchCL/cLogger.py
@@ -724,7 +724,7 @@ class cLogger:
 
             if self.state_manager.current_state.dd_trace_enabled:
                 # attach once per-handler
-                from _Internal.Logging.DatadogTraceInjectionFilter import DatadogTraceInjectionFilter
+                from ._Internal.Logging.DatadogTraceInjectionFilter import DatadogTraceInjectionFilter
                 if not any(isinstance(f, DatadogTraceInjectionFilter) for f in handler.filters):
                     handler.addFilter(DatadogTraceInjectionFilter())
 

--- a/tests/test_logger_json_mode.py
+++ b/tests/test_logger_json_mode.py
@@ -59,10 +59,11 @@ def test_json_log_format_and_metadata(logger_fixture):
 
     assert log_entry["message"] == "json test message"
     assert log_entry["level"] == "INFO"
-    trace = log_entry["trace"]
-    assert trace["dd.service"] == "ai-axis"
-    assert trace["dd.version"] == "1.2.3"
-    assert trace["dd.env"] == "dev"
+    assert log_entry["service"] == "ai-axis"
+    assert log_entry["version"] == "1.2.3"
+    assert log_entry["env"] == "dev"
+    assert "dd.trace_id" in log_entry
+    assert "dd.span_id" in log_entry
 
 
 def test_json_log_includes_exception(logger_fixture):


### PR DESCRIPTION
This pull request refactors the logging system to improve compatibility with Datadog by injecting trace and span IDs directly into log records and updating the JSON log format. It introduces a dedicated filter for Datadog trace injection, modernizes the JSON formatter to surface Datadog correlation fields at the top level, and updates the logger to automatically attach the new filter when Datadog tracing is enabled. Tests are updated to validate the new structure.

**Datadog Trace Injection & Logging Integration**
* Added a new `DatadogTraceInjectionFilter` in `WrenchCL/_Internal/Logging/DatadogTraceInjectionFilter.py` that injects `dd.trace_id` and `dd.span_id` fields into every log record, using the Datadog tracer if available.
* Updated `cLogger.py` to automatically attach the `DatadogTraceInjectionFilter` to all handlers when Datadog tracing is enabled, ensuring trace/span IDs are present in logs.

**JSON Log Formatter Modernization**
* Refactored `JSONLogFormatter` in `Formatters.py` to surface `service`, `env`, `version`, `dd.trace_id`, and `dd.span_id` as top-level fields in the JSON output, making logs Datadog-friendly and preserving existing context/exception structure.
* Improved context extraction logic in the formatter for more robust harvesting of user, organization, and service identifiers from context variables.

**Testing Updates**
* Modified tests in `test_logger_json_mode.py` to assert the presence of top-level Datadog correlation fields (`service`, `version`, `env`, `dd.trace_id`, `dd.span_id`) instead of the previous nested structure.