### PR TITLE
feat: add context prefix and fast frame resolution to cLogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,116 @@ Use the `--no-dependencies` flag to reinstall quickly if there are no dependency
 ```bash
 pip install ./dist/WrenchCL-0.0.1.dev0-py3-none-any.whl --force-reinstall --no-dependencies
 ```
+
+## Logger
+
+WrenchCL ships a structured, colorized logger available as a singleton:
+
+```python
+from WrenchCL import logger
+```
+
+### Output modes
+
+| Mode | When to use |
+|---|---|
+| `terminal` | Local development — colorized, multi-line, syntax-highlighted |
+| `json` | Deployed services — single-line JSON with Datadog triad fields |
+| `compact` | Space-constrained output — single-line, no color |
+
+```python
+logger.configure(mode="json")          # structured JSON
+logger.configure(mode="terminal")      # colored terminal output (default)
+logger.configure(deployment_mode=True) # deployed terminal — no color, shows context prefix
+```
+
+### Logging methods
+
+```python
+logger.debug("message")
+logger.info("message")
+logger.warning("message")
+logger.error("message")
+logger.critical("message")
+logger.exception("message")   # ERROR level + current exception info
+
+logger.data(obj)               # pretty-print dicts, DataFrames, Pydantic models
+logger.header("Section title") # formatted section header
+```
+
+### Context prefix
+
+In deployed or verbose mode every log line includes a bracket group that identifies the run, request context, and thread:
+
+```
+[A3X7K | api-handler | Thread-2 | WrenchCL] INFO    [12:34:56|file.py:10] -> message
+```
+
+**Scoped prefix** — the primary way to attach a prefix. Uses `contextvars.ContextVar` so it is per-context (thread and async-task safe) and cleans up automatically:
+
+```python
+# Context manager — prefix active only inside the block
+with logger.prefix("api-handler"):
+    logger.info("handling request")   # [run_id | api-handler | WrenchCL]
+
+logger.info("idle")                   # [run_id | WrenchCL]
+
+# Decorator — prefix active for the entire function or method call
+@logger.prefix("PaymentService")
+def process_payment(order_id):
+    logger.info("processing %s", order_id)
+```
+
+**Global prefix** — process-wide fallback, overridden by any scoped prefix:
+
+```python
+logger.set_prefix("worker-1")   # set
+logger.set_prefix()             # clear
+```
+
+**Thread name** — opt-in, off by default:
+
+```python
+logger.configure(show_thread_name=True)
+# [run_id | prefix | Thread-2 | WrenchCL]
+```
+
+**Run ID** — a 5-character uppercase alphanumeric ID generated at startup, refreshed with:
+
+```python
+logger.initiate_new_run()
+print(logger.run_id)   # e.g. "A3X7K"
+```
+
+### Datadog integration
+
+Install the `trace` extra and set `LOG_DD_TRACE=true`:
+
+```bash
+pip install WrenchCL[trace]
+LOG_DD_TRACE=true python app.py
+```
+
+`dd.trace_id` and `dd.span_id` are injected automatically into JSON log records for APM correlation. In AWS Lambda or ECS the logger auto-detects the environment and switches to JSON mode.
+
+### Configuration reference
+
+```python
+logger.configure(
+    mode="terminal",          # "terminal" | "json" | "compact"
+    level="INFO",             # "DEBUG" | "INFO" | "WARNING" | "ERROR" | "CRITICAL"
+    deployment_mode=False,    # strip color, activate context prefix
+    show_thread_name=False,   # include thread name in context bracket
+    prefix=None,              # global prefix string
+    color_enabled=True,
+    highlight_syntax=True,
+    trace_enabled=False,      # Datadog APM correlation
+)
+```
+
+Temporary overrides:
+
+```python
+with logger.temporary(level="DEBUG", mode="compact"):
+    logger.debug("verbose output for this block only")
+```

--- a/WrenchCL/_Internal/Logging/Api/base_logger.py
+++ b/WrenchCL/_Internal/Logging/Api/base_logger.py
@@ -197,6 +197,42 @@ class BaseLogger:
         """Set a contextual prefix prepended to all log output as [run_id | prefix | ...]"""
         self.state_manager.set_prefix(prefix)
 
+    def prefix(self, value: str):
+        """
+        Scoped log prefix — use as a context manager or decorator.
+
+        As a context manager:
+            with logger.prefix("api-handler"):
+                logger.info("...")   # shows prefix
+
+        As a decorator:
+            @logger.prefix("MyService")
+            def process(self):
+                logger.info("...")   # shows prefix for the whole call
+        """
+        from functools import wraps
+        from ..ContextFilter import _log_prefix_var
+
+        class _PrefixScope:
+            def __enter__(self_):
+                self_._token = _log_prefix_var.set(value)
+                return self_
+
+            def __exit__(self_, *args):
+                _log_prefix_var.reset(self_._token)
+
+            def __call__(self_, func):
+                @wraps(func)
+                def wrapper(*args, **kwargs):
+                    token = _log_prefix_var.set(value)
+                    try:
+                        return func(*args, **kwargs)
+                    finally:
+                        _log_prefix_var.reset(token)
+                return wrapper
+
+        return _PrefixScope()
+
     def header(
         self,
         text: str,

--- a/WrenchCL/_Internal/Logging/Api/base_logger.py
+++ b/WrenchCL/_Internal/Logging/Api/base_logger.py
@@ -193,6 +193,10 @@ class BaseLogger:
         with self._lock:
             self.state_manager.set_new_run_id()
 
+    def cycle_run(self):
+        """Generate a fresh run ID — call at the start of each Lambda invocation or job cycle."""
+        self.initiate_new_run()
+
     def set_prefix(self, prefix: Optional[str] = None) -> None:
         """Set a contextual prefix prepended to all log output as [run_id | prefix | ...]"""
         self.state_manager.set_prefix(prefix)

--- a/WrenchCL/_Internal/Logging/Api/base_logger.py
+++ b/WrenchCL/_Internal/Logging/Api/base_logger.py
@@ -10,6 +10,7 @@ from contextlib import contextmanager
 from typing import Any, Literal, Optional, Union
 
 from ..DataClasses import LogLevel, LogOptions, logLevels
+from ..LoggerConfigState import _UNSET
 from .internal_api import InternalAPI
 
 
@@ -155,6 +156,8 @@ class BaseLogger:
         trace_enabled: Optional[bool] = None,
         deployment_mode: Optional[bool] = None,
         suppress_autoconfig: bool = True,
+        prefix: object = _UNSET,
+        show_thread_name: Optional[bool] = None,
     ) -> None:
         """Configure logger behavior and settings"""
         if trace_enabled is not None:
@@ -170,6 +173,8 @@ class BaseLogger:
             trace_enabled=trace_enabled,
             deployment_mode=deployment_mode,
             suppress_autoconfig=suppress_autoconfig,
+            prefix=prefix,
+            show_thread_name=show_thread_name,
         )
         self.level = new_config.level
 
@@ -187,6 +192,10 @@ class BaseLogger:
         """Generate and assign a new run ID for process tracking"""
         with self._lock:
             self.state_manager.set_new_run_id()
+
+    def set_prefix(self, prefix: Optional[str] = None) -> None:
+        """Set a contextual prefix prepended to all log output as [run_id | prefix | ...]"""
+        self.state_manager.set_prefix(prefix)
 
     def header(
         self,

--- a/WrenchCL/_Internal/Logging/ContextFilter.py
+++ b/WrenchCL/_Internal/Logging/ContextFilter.py
@@ -1,0 +1,49 @@
+#  Copyright (c) 2025.
+#  Author: Willem van der Schans.
+#  Licensed under the MIT License (https://opensource.org/license/mit).
+import logging
+import threading
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .LoggerConfigState import LoggerStateManager
+
+
+class ContextPrefixFilter(logging.Filter):
+    """
+    Logging filter that injects contextual prefix fields onto every LogRecord.
+
+    Injected attributes:
+      record.wrench_context       str   Pre-built bracket string "[run_id | ...]" or ""
+      record.wrench_run_id        str   Run ID or "" when context is inactive
+      record.wrench_prefix        str   User-set prefix or ""
+      record.wrench_thread_name   str   Thread name or "" when show_thread_name is False
+    """
+
+    def __init__(self, state_manager: "LoggerStateManager") -> None:
+        super().__init__()
+        self._state_manager = state_manager
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        state = self._state_manager.current_state
+
+        if not state.should_show_env_prefix:
+            record.wrench_context = ""
+            record.wrench_run_id = ""
+            record.wrench_prefix = ""
+            record.wrench_thread_name = ""
+            return True
+
+        run_id: str = self._state_manager.run_id or ""
+        prefix: str = state.log_prefix or ""
+        thread_name: str = threading.current_thread().name if state.show_thread_name else ""
+        logger_name: str = record.name or ""
+
+        record.wrench_run_id = run_id
+        record.wrench_prefix = prefix
+        record.wrench_thread_name = thread_name
+
+        parts = [p for p in (run_id, prefix, thread_name, logger_name) if p]
+
+        record.wrench_context = ("[" + " | ".join(parts) + "] ") if parts else ""
+        return True

--- a/WrenchCL/_Internal/Logging/ContextFilter.py
+++ b/WrenchCL/_Internal/Logging/ContextFilter.py
@@ -3,10 +3,14 @@
 #  Licensed under the MIT License (https://opensource.org/license/mit).
 import logging
 import threading
-from typing import TYPE_CHECKING
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from .LoggerConfigState import LoggerStateManager
+
+
+_log_prefix_var: ContextVar[Optional[str]] = ContextVar("wrench_log_prefix", default=None)
 
 
 class ContextPrefixFilter(logging.Filter):
@@ -35,7 +39,8 @@ class ContextPrefixFilter(logging.Filter):
             return True
 
         run_id: str = self._state_manager.run_id or ""
-        prefix: str = state.log_prefix or ""
+        scoped_prefix: Optional[str] = _log_prefix_var.get()
+        prefix: str = scoped_prefix if scoped_prefix is not None else (state.log_prefix or "")
         thread_name: str = threading.current_thread().name if state.show_thread_name else ""
         logger_name: str = record.name or ""
 

--- a/WrenchCL/_Internal/Logging/Formatters.py
+++ b/WrenchCL/_Internal/Logging/Formatters.py
@@ -224,6 +224,17 @@ class JSONLogFormatter(logging.Formatter):
             "line": record.lineno,
             "timestamp": self._formatTime(record, self._TIMEFMT),
         }
+
+        run_id = getattr(record, "wrench_run_id", "")
+        if run_id:
+            log_record["run_id"] = run_id
+        prefix = getattr(record, "wrench_prefix", "")
+        if prefix:
+            log_record["prefix"] = prefix
+        thread_name = getattr(record, "wrench_thread_name", "")
+        if thread_name:
+            log_record["thread_name"] = thread_name
+
         if self.traced:
             log_record.update({
                 "service": service,
@@ -428,7 +439,8 @@ class FormatterFactory:
         elif level == "INTERNAL":
             format_str = f"{level_name_section}{colored_arrow_section}{message_section}"
         else:
-            format_str = f"{app_env_section}{name_section}{level_name_section}{verbose_section}{colored_arrow_section}{message_section}"
+            context_section = "%(wrench_context)s" if not global_stream_configured else ""
+            format_str = f"{app_env_section}{context_section}{name_section}{level_name_section}{verbose_section}{colored_arrow_section}{message_section}"
 
         return {
             "format": format_str,

--- a/WrenchCL/_Internal/Logging/LoggerConfigState.py
+++ b/WrenchCL/_Internal/Logging/LoggerConfigState.py
@@ -17,6 +17,8 @@ from .logging_utils import generate_run_id
 from .LogManagers import GlobalLoggerManager, HandlerManager
 from .MessageProcessors import MarkupProcessor, MessageProcessor
 
+_UNSET: object = object()
+
 
 @dataclass(frozen=True)  # Immutable config state
 class LoggerConfigState:
@@ -29,6 +31,8 @@ class LoggerConfigState:
     dd_trace_enabled: bool = False
     color_enabled: bool = True
     force_markup: bool = False
+    log_prefix: Optional[str] = None
+    show_thread_name: bool = False
     level: LogLevel = LogLevel("INFO")
 
     # Derived properties - computed from base config
@@ -229,6 +233,8 @@ class LoggerStateManager:
             )
             self.logging_instance.propagate = False
             self.__initialized = True
+            from .ContextFilter import ContextPrefixFilter
+            self.logging_instance.addFilter(ContextPrefixFilter(self))
             return True
 
     @property
@@ -251,6 +257,10 @@ class LoggerStateManager:
         with self._lock:
             self._run_id = generate_run_id()
         return self._run_id
+
+    def set_prefix(self, prefix: Optional[str] = None) -> None:
+        """Set or clear the contextual log prefix shown in all output."""
+        self.configure(prefix=prefix)
 
     @property
     def initialized(self) -> bool:
@@ -302,6 +312,8 @@ class LoggerStateManager:
         deployment_mode: Optional[bool] = None,
         force_markup: Optional[bool] = None,
         suppress_autoconfig: Optional[bool] = False,
+        prefix: object = _UNSET,
+        show_thread_name: Optional[bool] = None,
     ) -> LoggerConfigState:
         """
         Configure state and apply ALL side effects.
@@ -345,6 +357,10 @@ class LoggerStateManager:
                 changes["dd_trace_enabled"] = trace_enabled
             if force_markup is not None:
                 changes["force_markup"] = force_markup
+            if prefix is not _UNSET:
+                changes["log_prefix"] = prefix  # None explicitly clears the prefix
+            if show_thread_name is not None:
+                changes["show_thread_name"] = show_thread_name
 
             old_state = self._state
             new_state = replace(self._state, **changes)

--- a/WrenchCL/_Internal/Logging/LoggerConfigState.py
+++ b/WrenchCL/_Internal/Logging/LoggerConfigState.py
@@ -358,7 +358,7 @@ class LoggerStateManager:
             if force_markup is not None:
                 changes["force_markup"] = force_markup
             if prefix is not _UNSET:
-                changes["log_prefix"] = prefix  # None explicitly clears the prefix
+                changes["log_prefix"] = str(prefix) if prefix is not None else None
             if show_thread_name is not None:
                 changes["show_thread_name"] = show_thread_name
 

--- a/WrenchCL/_Internal/Logging/logging_utils.py
+++ b/WrenchCL/_Internal/Logging/logging_utils.py
@@ -1,7 +1,9 @@
 #  Copyright (c) 2025.
 #  Author: Willem van der Schans.
 #  Licensed under the MIT License (https://opensource.org/license/mit).
+import random
 import re
+import string
 import sys
 import threading
 from types import FrameType
@@ -73,6 +75,7 @@ def _measure_base_level() -> int:
 
     _logger = logging.getLogger("_wcl_depth_probe")
     _logger.propagate = False
+    _logger.setLevel(logging.DEBUG)
     _h = _Probe()
     _logger.addHandler(_h)
     try:
@@ -129,9 +132,15 @@ def suggest_exception(args) -> Optional[str]:
     return suggestion
 
 
+_RUN_ID_CHARS: str = string.ascii_uppercase + string.digits
+
+
 def generate_run_id() -> str:
-    """Generate a unique 5-character uppercase alphanumeric run ID."""
-    import random
-    import string
-    chars = string.ascii_uppercase + string.digits
-    return "".join(random.choices(chars, k=5))
+    """
+    Generate a unique 5-character uppercase alphanumeric run ID.
+
+    ID space is 36^5 (~60 M). Collision probability reaches ~50% at roughly
+    7,700 simultaneously active IDs — sufficient for log correlation within a
+    single service instance but not intended as a cryptographic identifier.
+    """
+    return "".join(random.choices(_RUN_ID_CHARS, k=5))

--- a/WrenchCL/_Internal/Logging/logging_utils.py
+++ b/WrenchCL/_Internal/Logging/logging_utils.py
@@ -1,10 +1,10 @@
 #  Copyright (c) 2025.
 #  Author: Willem van der Schans.
 #  Licensed under the MIT License (https://opensource.org/license/mit).
-import inspect
-import os
 import re
-from datetime import datetime
+import sys
+import threading
+from types import FrameType
 from typing import Any, Callable, Optional
 
 
@@ -38,24 +38,76 @@ def ensure_str(val: bytes | str) -> Any:
     return val.decode("utf-8") if isinstance(val, bytes) else val
 
 
-def get_depth(internal=False) -> int:
-    """Get stack depth to determine log source."""
+_WCL_MODULE_PREFIX = "WrenchCL"
+_FRAME_WALK_LIMIT = 25
+_PROBE_DEPTH = 500
+_cached_base_level: Optional[int] = None
+_base_level_lock = threading.Lock()
+
+
+def _owns_frame(frame: FrameType) -> bool:
+    """Return True when the frame belongs to the WrenchCL package."""
+    return str(frame.f_globals.get("__name__", "")).startswith(_WCL_MODULE_PREFIX)
+
+
+def _measure_base_level() -> int:
+    """
+    Emit one probe record and walk its frame chain to find the first
+    non-WrenchCL frame. Result is cached for the process lifetime.
+    """
+    import logging
+
+    measured = 3
+
+    class _Probe(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            nonlocal measured
+            f: Optional[FrameType] = sys._getframe(0)
+            for depth in range(1, _PROBE_DEPTH):
+                if f is None:
+                    break
+                if not _owns_frame(f):
+                    measured = depth
+                    return
+                f = f.f_back
+
+    _logger = logging.getLogger("_wcl_depth_probe")
+    _logger.propagate = False
+    _h = _Probe()
+    _logger.addHandler(_h)
     try:
-        for i, frame in enumerate(inspect.stack()):
-            if (
-                frame.filename.endswith("cLogger.py")
-                or "WrenchCL" in frame.filename
-                or frame.filename == "<string>"
-            ):
-                if internal:
-                    return i + 2
-                else:
-                    continue
-            return i
-    except Exception:
+        _logger.debug("probe")
+    finally:
+        _logger.removeHandler(_h)
+    return measured
+
+
+def get_depth(internal: bool = False) -> int:
+    """
+    Return the stacklevel needed to attribute a log record to the caller's
+    call site rather than to WrenchCL internals.
+
+    Walks frames lazily via sys._getframe. Falls back to a one-time measured
+    baseline when the walk exhausts the depth limit or fails.
+    """
+    offset = 1 if internal else 0
+    try:
+        frame: Optional[FrameType] = sys._getframe(2)
+        for depth in range(1, _FRAME_WALK_LIMIT):
+            if frame is None:
+                break
+            if not _owns_frame(frame):
+                return depth + offset
+            frame = frame.f_back
+    except (ValueError, AttributeError):
         pass
-    # Fallback: If stack inspection fails, return depth 1 (assume direct caller).
-    return 1
+
+    global _cached_base_level
+    if _cached_base_level is None:
+        with _base_level_lock:
+            if _cached_base_level is None:
+                _cached_base_level = _measure_base_level()
+    return (_cached_base_level + offset) if _cached_base_level is not None else (1 + offset)
 
 
 def suggest_exception(args) -> Optional[str]:
@@ -78,6 +130,8 @@ def suggest_exception(args) -> Optional[str]:
 
 
 def generate_run_id() -> str:
-    """Generate a unique run ID for this logger instance."""
-    now = datetime.now()
-    return f"R-{os.urandom(1).hex().upper()}{now.strftime('%m%d')}{os.urandom(1).hex().upper()}"
+    """Generate a unique 5-character uppercase alphanumeric run ID."""
+    import random
+    import string
+    chars = string.ascii_uppercase + string.digits
+    return "".join(random.choices(chars, k=5))

--- a/tests/test_context_prefix.py
+++ b/tests/test_context_prefix.py
@@ -1,0 +1,379 @@
+"""
+Tests for context prefix features: run_id, set_prefix, logger.prefix(),
+show_thread_name, JSON field injection, and ContextPrefixFilter.
+"""
+import json
+import logging
+import re
+import threading
+from io import StringIO
+
+import pytest
+
+from WrenchCL import logger
+
+
+def strip_ansi(text: str) -> str:
+    return re.sub(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', '', text)
+
+
+@pytest.fixture
+def deployed_stream():
+    stream = StringIO()
+    logger.configure(deployment_mode=True, color_enabled=False)
+    logger.instance.handlers.clear()
+    logger.managed.add(logging.StreamHandler, stream=stream, owned=True)
+    yield logger, stream
+    logger.set_prefix()
+    logger.configure(mode="terminal", color_enabled=True, show_thread_name=False)
+    logger.instance.handlers.clear()
+
+
+@pytest.fixture
+def terminal_stream():
+    stream = StringIO()
+    logger.configure(mode="terminal", color_enabled=False, deployment_mode=False, verbose=False)
+    logger.instance.handlers.clear()
+    logger.managed.add(logging.StreamHandler, stream=stream, owned=True)
+    yield logger, stream
+    logger.set_prefix()
+    logger.configure(mode="terminal", color_enabled=True, show_thread_name=False, deployment_mode=False, verbose=False)
+    logger.instance.handlers.clear()
+
+
+@pytest.fixture
+def json_stream():
+    stream = StringIO()
+    logger.configure(mode="json")
+    logger.instance.handlers.clear()
+    logger.managed.add(logging.StreamHandler, stream=stream, owned=True)
+    yield logger, stream
+    logger.set_prefix()
+    logger.configure(mode="terminal", color_enabled=True, show_thread_name=False)
+    logger.instance.handlers.clear()
+
+
+class TestRunId:
+
+    def test_run_id_format(self, deployed_stream):
+        lg, _ = deployed_stream
+        run_id = lg.run_id
+        assert len(run_id) == 5
+        assert run_id.isalnum()
+        assert run_id.isupper()
+
+    def test_run_id_appears_in_deployed_output(self, deployed_stream):
+        lg, stream = deployed_stream
+        run_id = lg.run_id
+        lg.info("probe")
+        lg.flush()
+        assert run_id in stream.getvalue()
+
+    def test_run_id_absent_in_plain_terminal(self, terminal_stream):
+        lg, stream = terminal_stream
+        run_id = lg.run_id
+        lg.info("probe")
+        lg.flush()
+        assert run_id not in strip_ansi(stream.getvalue())
+
+    def test_cycle_run_generates_new_id(self, deployed_stream):
+        lg, _ = deployed_stream
+        old_id = lg.run_id
+        lg.cycle_run()
+        assert lg.run_id != old_id
+        assert len(lg.run_id) == 5
+
+    def test_initiate_new_run_also_works(self, deployed_stream):
+        lg, _ = deployed_stream
+        old_id = lg.run_id
+        lg.initiate_new_run()
+        assert lg.run_id != old_id
+
+
+class TestContextBracket:
+
+    def test_bracket_present_in_deployed_mode(self, deployed_stream):
+        lg, stream = deployed_stream
+        lg.info("msg")
+        lg.flush()
+        output = stream.getvalue()
+        assert "[" in output and "]" in output
+
+    def test_bracket_present_in_verbose_mode(self, terminal_stream):
+        lg, stream = terminal_stream
+        lg.configure(verbose=True)
+        lg.info("msg")
+        lg.flush()
+        output = strip_ansi(stream.getvalue())
+        assert "[" in output and "]" in output
+        lg.configure(verbose=False)
+
+    def test_bracket_absent_in_plain_terminal(self, terminal_stream):
+        lg, stream = terminal_stream
+        run_id = lg.run_id
+        lg.info("msg")
+        lg.flush()
+        assert run_id not in strip_ansi(stream.getvalue())
+
+
+class TestSetPrefix:
+
+    def test_set_prefix_appears_in_output(self, deployed_stream):
+        lg, stream = deployed_stream
+        lg.set_prefix("myprefix")
+        lg.info("msg")
+        lg.flush()
+        assert "myprefix" in stream.getvalue()
+
+    def test_set_prefix_clear_removes_prefix(self, deployed_stream):
+        lg, stream = deployed_stream
+        lg.set_prefix("tempprefix")
+        lg.set_prefix()
+        lg.info("msg")
+        lg.flush()
+        assert "tempprefix" not in stream.getvalue()
+
+    def test_configure_prefix_param(self, deployed_stream):
+        lg, stream = deployed_stream
+        lg.configure(prefix="cfgprefix")
+        lg.info("msg")
+        lg.flush()
+        assert "cfgprefix" in stream.getvalue()
+        lg.set_prefix()
+
+    def test_prefix_coerced_to_str(self, deployed_stream):
+        lg, stream = deployed_stream
+        lg.configure(prefix="coerced")
+        state = lg.state_manager.current_state
+        assert isinstance(state.log_prefix, str)
+        lg.set_prefix()
+
+    def test_configure_does_not_clear_existing_prefix(self, deployed_stream):
+        lg, stream = deployed_stream
+        lg.set_prefix("persistent")
+        lg.configure(show_thread_name=False)
+        lg.info("msg")
+        lg.flush()
+        assert "persistent" in stream.getvalue()
+        lg.set_prefix()
+
+
+class TestScopedPrefix:
+
+    def test_context_manager_active_inside(self, deployed_stream):
+        lg, stream = deployed_stream
+        with lg.prefix("scoped"):
+            lg.info("inside")
+        lg.flush()
+        assert "scoped" in stream.getvalue()
+
+    def test_context_manager_inactive_outside(self, deployed_stream):
+        lg, stream = deployed_stream
+        with lg.prefix("scoped"):
+            pass
+        stream.truncate(0)
+        stream.seek(0)
+        lg.info("outside")
+        lg.flush()
+        assert "scoped" not in stream.getvalue()
+
+    def test_decorator_active_during_call(self, deployed_stream):
+        lg, stream = deployed_stream
+
+        @lg.prefix("decorated")
+        def work():
+            lg.info("inside fn")
+
+        work()
+        lg.flush()
+        assert "decorated" in stream.getvalue()
+
+    def test_decorator_inactive_after_call(self, deployed_stream):
+        lg, stream = deployed_stream
+
+        @lg.prefix("decorated")
+        def work():
+            pass
+
+        work()
+        stream.truncate(0)
+        stream.seek(0)
+        lg.info("after fn")
+        lg.flush()
+        assert "decorated" not in stream.getvalue()
+
+    def test_scoped_overrides_global(self, deployed_stream):
+        lg, stream = deployed_stream
+        lg.set_prefix("global")
+        with lg.prefix("scoped"):
+            lg.info("msg")
+        lg.flush()
+        output = stream.getvalue()
+        assert "scoped" in output
+        assert "global" not in output
+        lg.set_prefix()
+
+    def test_global_restored_after_scope_exits(self, deployed_stream):
+        lg, stream = deployed_stream
+        lg.set_prefix("global")
+        with lg.prefix("scoped"):
+            pass
+        stream.truncate(0)
+        stream.seek(0)
+        lg.info("msg")
+        lg.flush()
+        output = stream.getvalue()
+        assert "global" in output
+        assert "scoped" not in output
+        lg.set_prefix()
+
+    def test_context_manager_cleans_up_on_exception(self, deployed_stream):
+        lg, stream = deployed_stream
+        try:
+            with lg.prefix("errscope"):
+                raise ValueError("boom")
+        except ValueError:
+            pass
+        stream.truncate(0)
+        stream.seek(0)
+        lg.info("after error")
+        lg.flush()
+        assert "errscope" not in stream.getvalue()
+
+
+class TestThreadName:
+
+    def test_thread_name_absent_by_default(self, deployed_stream):
+        lg, stream = deployed_stream
+        thread_name = threading.current_thread().name
+        lg.info("msg")
+        lg.flush()
+        assert thread_name not in stream.getvalue()
+
+    def test_thread_name_present_when_enabled(self, deployed_stream):
+        lg, stream = deployed_stream
+        lg.configure(show_thread_name=True)
+        thread_name = threading.current_thread().name
+        lg.info("msg")
+        lg.flush()
+        assert thread_name in stream.getvalue()
+        lg.configure(show_thread_name=False)
+
+    def test_thread_name_reflects_current_thread(self, deployed_stream):
+        lg, stream = deployed_stream
+        lg.configure(show_thread_name=True)
+        results = []
+
+        def worker():
+            lg.info("from thread")
+            lg.flush()
+            results.append(stream.getvalue())
+
+        t = threading.Thread(target=worker, name="WorkerThread-99")
+        t.start()
+        t.join()
+        assert "WorkerThread-99" in results[-1]
+        lg.configure(show_thread_name=False)
+
+
+class TestJsonMode:
+
+    def test_json_includes_run_id(self, json_stream):
+        lg, stream = json_stream
+        run_id = lg.run_id
+        lg.info("msg")
+        lg.flush()
+        record = json.loads(stream.getvalue().strip())
+        assert record.get("run_id") == run_id
+
+    def test_json_includes_prefix_when_set(self, json_stream):
+        lg, stream = json_stream
+        lg.set_prefix("jsonprefix")
+        lg.info("msg")
+        lg.flush()
+        record = json.loads(stream.getvalue().strip())
+        assert record.get("prefix") == "jsonprefix"
+        lg.set_prefix()
+
+    def test_json_omits_prefix_when_not_set(self, json_stream):
+        lg, stream = json_stream
+        lg.set_prefix()
+        lg.info("msg")
+        lg.flush()
+        record = json.loads(stream.getvalue().strip())
+        assert "prefix" not in record
+
+    def test_json_includes_thread_name_when_enabled(self, json_stream):
+        lg, stream = json_stream
+        lg.configure(show_thread_name=True)
+        thread_name = threading.current_thread().name
+        lg.info("msg")
+        lg.flush()
+        record = json.loads(stream.getvalue().strip())
+        assert record.get("thread_name") == thread_name
+        lg.configure(show_thread_name=False)
+
+    def test_json_omits_thread_name_when_disabled(self, json_stream):
+        lg, stream = json_stream
+        lg.configure(show_thread_name=False)
+        lg.info("msg")
+        lg.flush()
+        record = json.loads(stream.getvalue().strip())
+        assert "thread_name" not in record
+
+
+class TestContextFilter:
+
+    def test_filter_sets_attributes_when_active(self, deployed_stream):
+        lg, _ = deployed_stream
+        import logging as stdlib_logging
+        record = stdlib_logging.LogRecord(
+            name="test", level=stdlib_logging.INFO,
+            pathname="", lineno=0, msg="test", args=(), exc_info=None
+        )
+        f = next(f for f in lg.instance.filters
+                 if type(f).__name__ == "ContextPrefixFilter")
+        f.filter(record)
+        assert hasattr(record, "wrench_context")
+        assert hasattr(record, "wrench_run_id")
+        assert hasattr(record, "wrench_prefix")
+        assert hasattr(record, "wrench_thread_name")
+        assert record.wrench_run_id == lg.run_id
+
+    def test_filter_clears_attributes_when_inactive(self, terminal_stream):
+        lg, _ = terminal_stream
+        import logging as stdlib_logging
+        record = stdlib_logging.LogRecord(
+            name="test", level=stdlib_logging.INFO,
+            pathname="", lineno=0, msg="test", args=(), exc_info=None
+        )
+        f = next(f for f in lg.instance.filters
+                 if type(f).__name__ == "ContextPrefixFilter")
+        f.filter(record)
+        assert record.wrench_context == ""
+        assert record.wrench_run_id == ""
+
+    def test_filter_always_returns_true(self, deployed_stream):
+        lg, _ = deployed_stream
+        import logging as stdlib_logging
+        record = stdlib_logging.LogRecord(
+            name="test", level=stdlib_logging.INFO,
+            pathname="", lineno=0, msg="test", args=(), exc_info=None
+        )
+        f = next(f for f in lg.instance.filters
+                 if type(f).__name__ == "ContextPrefixFilter")
+        assert f.filter(record) is True
+
+
+class TestCalibrationProbe:
+
+    def test_measure_base_level_probe_fires(self):
+        from WrenchCL._Internal.Logging.logging_utils import _measure_base_level
+        result = _measure_base_level()
+        assert isinstance(result, int)
+        assert result != 3 or result >= 1
+
+    def test_measure_base_level_returns_positive_int(self):
+        from WrenchCL._Internal.Logging.logging_utils import _measure_base_level
+        result = _measure_base_level()
+        assert result >= 1


### PR DESCRIPTION
Before this change the logger had no way to correlate log lines to a specific run, request context, or thread — in deployed mode every line looked identical except for the message. Debugging multi-threaded or multi-request workloads meant grepping with no anchor. The README also had no logger documentation at all.

## What changed

**Context prefix bracket** — every log line in deployed or verbose mode now shows a bracket group prepended to the level:

```
[A3X7K | api-handler | Thread-2 | WrenchCL] INFO    [12:34:56|...] -> message
```

Components are omitted when inactive — with only a run_id it shows `[A3X7K | WrenchCL]`.

**Scoped prefix (`logger.prefix()`)** — the primary API. Uses `contextvars.ContextVar` so it is per-context (thread and async-task safe) and cleans up automatically on scope exit. Works as both a context manager and a decorator:

```python
with logger.prefix("api-handler"):
    logger.info("...")   # [run_id | api-handler | WrenchCL]
logger.info("...")       # [run_id | WrenchCL] — clean

@logger.prefix("PaymentService")
def process(order_id):
    logger.info("...")   # [run_id | PaymentService | WrenchCL]
```

Scoped prefix overrides global when both are set, and resets automatically — no cleanup needed.

**Global prefix (`logger.set_prefix()`)** — process-wide fallback for cases where a single prefix applies everywhere. `logger.set_prefix()` with no argument clears it.

**Thread name opt-in** — `logger.configure(show_thread_name=True)`.

**New `ContextPrefixFilter`** (`ContextFilter.py`) — a `logging.Filter` attached to the WrenchCL logger instance that injects context fields onto every `LogRecord` at emit time. Thread name and scoped prefix resolve at log time so they are always current regardless of when the filter was attached.

**Run ID format** — changed from `R-{hex}{MMDD}{hex}` to a clean 5-character uppercase alphanumeric string (e.g. `WO8B8`).

**JSON mode** — `run_id`, `prefix`, and `thread_name` added as top-level fields when populated, fitting alongside the Datadog triad.

**Faster frame resolution** — replaced `inspect.stack()` in `get_depth()` with a `sys._getframe()` lazy walk and a one-time calibration probe. `inspect.stack()` materialises the entire call stack as a list on every log call; the new approach walks lazily and stops at the first non-WrenchCL frame, with a cached fallback.

**README** — added a full Logger section covering output modes, all logging methods, context prefix usage with examples, Datadog integration, and the configuration reference.

## Sales impact

Customers running WrenchCL services in production can correlate every log line to a specific run, request handler, and thread without any custom instrumentation — directly useful for debugging multi-tenant workloads and async pipelines in Datadog.

## References

- PR #144