### PR TITLE
fix: tighten logspark floor to >=0.10.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "filetype>=1.2,<2.0",
     "ansi2txt>=0.2.0,<1.0.0",
     "ftfy>=6.3.1,<7.0.0",
-    "logspark>=0.10.1",
+    "logspark>=0.10.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem

LogSpark `0.10.2` (released 2026-06-10) fixes stacklevel derivation from the logger class MRO. Without it, log lines emitted through `WrenchLogger` (which inherits `SparkLogger`) can report the wrong file/function/line — showing WrenchCL internals instead of the actual calling code.

WrenchCL was pinned at `logspark>=0.10.1`, which technically allows `0.10.2`, but Docker layer caching means services built before the release will stay on `0.10.1` until forced. This PR raises the floor to `>=0.10.2` so the next WrenchCL version enforces the fix.

## Change

`pyproject.toml`: `logspark>=0.10.1` → `logspark>=0.10.2`

## End-user impact
Log lines across all 9 pipeline services will correctly report the application code location (file, function, line) rather than WrenchCL wrapper internals. Improves debuggability of production failures.