### PR TITLE
fix: require logspark[json] to pull python-json-logger

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "filetype>=1.2,<2.0",
     "ansi2txt>=0.2.0,<1.0.0",
     "ftfy>=6.3.1,<7.0.0",
-    "logspark>=0.10.2",
+    "logspark[json]>=0.10.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem

LogSpark 0.10.2 (pinned in 6.0.5) requires `python-json-logger` for `SparkJsonHandler`. WrenchCL was pinning `logspark>=0.10.2` without the `[json]` extra, so `python-json-logger` was not installed. Any ECS service running in deployment mode (which uses `SparkJsonHandler` for structured JSON logs) crashes on startup with:

```
ModuleNotFoundError: No module named 'pythonjsonlogger'
logspark.Types.Exceptions.MissingDependencyException: Missing required dependencies: python-json-logger
```

This caused `model-input-builder-prep` to exit code 1 inside the `ai-pipeline` Step Function, making every scheduled pipeline run fail. All other ECS services rebuilt at the same time will hit the same crash on their next invocation.

## Fix

Changed `logspark>=0.10.2` to `logspark[json]>=0.10.2` so the JSON extra (and its `python-json-logger` transitive dependency) is always installed with WrenchCL.

## End-user impact
Restores pipeline execution for all ECS services. Without this fix, every service rebuilt against WrenchCL 6.0.5 crashes at startup.