### PR TITLE
fix: add python-json-logger as direct dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "ansi2txt>=0.2.0,<1.0.0",
     "ftfy>=6.3.1,<7.0.0",
     "logspark[json]>=0.10.2",
+    "python-json-logger>=2.0,<4.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
logspark[json] pulls python-json-logger transitively, but Docker layer caching means services that haven't rebuilt since 6.0.5 still lack it. Adding python-json-logger as a direct WrenchCL dependency ensures it is always installed regardless of cache state or whether the logspark[json] extra resolves correctly.