### PR TITLE
chore: upgrade logspark to 0.11.0 and python-json-logger to 4.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ dependencies = [
     "filetype>=1.2,<2.0",
     "ansi2txt>=0.2.0,<1.0.0",
     "ftfy>=6.3.1,<7.0.0",
-    "logspark[json]>=0.10.2",
-    "python-json-logger>=2.0,<4.0",
+    "logspark[json]~=0.11.0",
+    "python-json-logger>=4.0,<5.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "ansi2txt>=0.2.0,<1.0.0",
     "ftfy>=6.3.1,<7.0.0",
     "logspark[json]>=0.10.2",
+    "python-json-logger>=2.0,<4.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -691,11 +691,16 @@ wheels = [
 
 [[package]]
 name = "logspark"
-version = "0.10.1"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/77/d7dc530a810e24817ce900923da36b099e3cddf3512a864152a5a2a9bd00/logspark-0.10.1.tar.gz", hash = "sha256:e15cbd43491b352a7306a4049aa3449e3ae4142e41f8fe45cf2093b462b08c15", size = 36902, upload-time = "2026-04-04T23:58:37.025Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8f/d6/389a80a3304a649a2b91a44864a6bcd40d0bec9d48566bd8a5f63ed2e409/logspark-0.11.0.tar.gz", hash = "sha256:8b253400049e5047da14c1e65f2cef47828e15caa54da1b3eb60bf966dc1449e", size = 38157, upload-time = "2026-06-12T20:33:29.692Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/e6/0f80d021c10663b9375c6ed065068cc2f8eeb2c19909ed01452c9a20415b/logspark-0.10.1-py3-none-any.whl", hash = "sha256:3baa58bd18ac7c145d9c924e6793bff1d48d5413d01d47fe3942e2c168e84d71", size = 52427, upload-time = "2026-04-04T23:58:35.492Z" },
+    { url = "https://files.pythonhosted.org/packages/54/d9/1bf737feb13ba6339fc27f27c82f2c228a22924b25a3f52471c80020ac78/logspark-0.11.0-py3-none-any.whl", hash = "sha256:37d873d5396b0f5de3561933189b7bd881658f5ebdcd660d349610fc0a3b9131", size = 53849, upload-time = "2026-06-12T20:33:28.359Z" },
+]
+
+[package.optional-dependencies]
+json = [
+    { name = "python-json-logger" },
 ]
 
 [[package]]
@@ -1531,6 +1536,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1963,9 +1977,34 @@ dependencies = [
     { name = "ansi2txt" },
     { name = "filetype" },
     { name = "ftfy" },
-    { name = "logspark" },
+    { name = "logspark", extra = ["json"] },
     { name = "python-dotenv" },
+    { name = "python-json-logger" },
     { name = "requests" },
+]
+
+[package.optional-dependencies]
+all = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "colorama" },
+    { name = "ddtrace" },
+    { name = "paramiko" },
+    { name = "psycopg2" },
+    { name = "sshtunnel" },
+]
+aws = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "paramiko" },
+    { name = "psycopg2" },
+    { name = "sshtunnel" },
+]
+color = [
+    { name = "colorama" },
+]
+trace = [
+    { name = "ddtrace" },
 ]
 
 [package.dev-dependencies]
@@ -2055,12 +2094,28 @@ trace = [
 [package.metadata]
 requires-dist = [
     { name = "ansi2txt", specifier = ">=0.2.0,<1.0.0" },
+    { name = "boto3", marker = "extra == 'all'", specifier = ">=1.28,<2.0" },
+    { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.28,<2.0" },
+    { name = "botocore", marker = "extra == 'all'", specifier = ">=1.31,<2.0" },
+    { name = "botocore", marker = "extra == 'aws'", specifier = ">=1.31,<2.0" },
+    { name = "colorama", marker = "extra == 'all'", specifier = ">=0.4,<1.0" },
+    { name = "colorama", marker = "extra == 'color'", specifier = ">=0.4,<1.0" },
+    { name = "ddtrace", marker = "extra == 'all'", specifier = ">=3.2.0,<3.3.0" },
+    { name = "ddtrace", marker = "extra == 'trace'", specifier = ">=3.2.0,<3.3.0" },
     { name = "filetype", specifier = ">=1.2,<2.0" },
     { name = "ftfy", specifier = ">=6.3.1,<7.0.0" },
-    { name = "logspark", specifier = ">=0.10.1" },
+    { name = "logspark", extras = ["json"], specifier = "~=0.11.0" },
+    { name = "paramiko", marker = "extra == 'all'", specifier = "==3.5.1" },
+    { name = "paramiko", marker = "extra == 'aws'", specifier = "==3.5.1" },
+    { name = "psycopg2", marker = "extra == 'all'", specifier = ">=2.9,<3.0" },
+    { name = "psycopg2", marker = "extra == 'aws'", specifier = ">=2.9,<3.0" },
     { name = "python-dotenv", specifier = ">=1.0,<2.0" },
+    { name = "python-json-logger", specifier = ">=4.0,<5.0" },
     { name = "requests", specifier = ">=2.32,<3.0" },
+    { name = "sshtunnel", marker = "extra == 'all'", specifier = ">=0.4,<1.0" },
+    { name = "sshtunnel", marker = "extra == 'aws'", specifier = ">=0.4,<1.0" },
 ]
+provides-extras = ["all", "aws", "color", "trace"]
 
 [package.metadata.requires-dev]
 all = [


### PR DESCRIPTION
## Summary

- Pins `logspark[json]~=0.11.0` (was `>=0.10.2` with no ceiling — was resolving to the yanked 1.1.0 on fresh installs)
- Aligns `python-json-logger>=4.0,<5.0` to match the new logspark 0.11.0 `[json]` extra requirement (was `>=2.0,<4.0`, which conflicts with logspark 0.11.0)
- Adds `python-json-logger` as an explicit direct dependency so it is guaranteed present regardless of how logspark extras resolve
- Regenerates `uv.lock` to logspark 0.11.0 + python-json-logger 4.1.0

## Why now

`logspark` published 0.11.0 today and simultaneously the existing 1.1.0 tag is yanked (invalid). Without an upper bound, `>=0.10.2` was resolving to 1.1.0 on fresh installs. This PR locks us into the supported 0.11.x series.

## Downstream

After this merges, `v6.1.0` will be tagged on `release` to publish to PyPI, followed by a version bump across all 6.x downstream repos.

## End-user impact

No API changes. This is a dependency hygiene fix — existing consumers get a stable, non-yanked logspark install.